### PR TITLE
Completed Screen Mirror Tool

### DIFF
--- a/tools/screen mirror/mirror.html
+++ b/tools/screen mirror/mirror.html
@@ -4,29 +4,75 @@
     <title>Toolsuite: Screen Mirror</title>
     <style>
         body { font-family: 'Courier New', monospace; background: #fff; color: #000; text-align: center; padding: 20px; }
-        .container { max-width: 600px; margin: 0 auto; border: 3px solid #000; padding: 20px; }
-        video { width: 100%; border: 3px solid #000; margin-top: 20px; background: #000; }
-        input { padding: 10px; border: 2px solid #000; font-family: inherit; width: 60%; }
-        button { background: #000; color: #fff; border: none; padding: 10px 20px; cursor: pointer; margin: 5px; }
-        .status { margin: 10px; font-weight: bold; }
-        .hidden { display: none; }
+        .container { max-width: 800px; margin: 0 auto; border: 3px solid #000; padding: 20px; }
+        
+        .video-wrapper {
+            position: relative;
+            width: 100%;
+            border: 3px solid #000;
+            margin-top: 20px;
+            background: #000;
+            min-height: 400px;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+        }
+        
+        /* Ensure video fills the container */
+        video { width: 100%; height: 100%; display: block; object-fit: contain; }
+
+        input { padding: 10px; border: 2px solid #000; font-family: inherit; width: 200px; text-align: center; }
+        
+        button { 
+            background: #fff; color: #000; border: 2px solid #000; 
+            padding: 10px 20px; cursor: pointer; margin: 5px; 
+            font-weight: bold; text-transform: uppercase;
+        }
+        button:hover { background: #000; color: #fff; }
+
+        .btn-stop { border-color: #d00; color: #d00; }
+        .btn-stop:hover { background: #d00; color: #fff; }
+
+        .status { margin: 15px 0; font-weight: bold; font-size: 1.1rem; }
+        .hidden { display: none !important; }
+        
+        hr { border: none; border-top: 1px solid #000; margin: 30px 0; }
+        .code-display { font-size: 2.5rem; letter-spacing: 5px; display: block; margin: 10px 0; }
     </style>
 </head>
 <body>
     <div class="container">
         <h1>Screen Mirror</h1>
+        <p>Share your screen to another device on the same network.</p>
         
         <div id="setup-zone">
-            <button onclick="startSharing()">Generate Share Code</button>
+            <div style="margin-bottom: 40px;">
+                <h3>I want to SHARE my screen</h3>
+                <button onclick="startSharing()">Generate Host Code</button>
+            </div>
             <hr>
-            <input type="text" id="joinCode" placeholder="Enter 4-digit code">
-            <button onclick="joinStream()">Watch Screen</button>
+            <div>
+                <h3>I want to WATCH a screen</h3>
+                <input type="text" id="joinCode" placeholder="Enter 4-digit Code" maxlength="4">
+                <br><br>
+                <button onclick="joinStream()">Connect & Watch</button>
+            </div>
         </div>
 
         <div id="display-zone" class="hidden">
-            <p id="share-id-display"></p>
-            <p class="status" id="status-text">Ready...</p>
-            <video id="videoElement" autoplay playsinline muted></video>
+            <div id="host-info">
+                <p>Share this code with the viewer:</p>
+                <strong id="share-id-display" class="code-display">----</strong>
+            </div>
+
+            <p class="status" id="status-text">Initializing...</p>
+            
+            <div class="video-wrapper">
+                <video id="videoElement" autoplay playsinline></video>
+            </div>
+
+            <br>
+            <button onclick="stopSharing()" class="btn-stop">Stop / Disconnect</button>
         </div>
     </div>
 


### PR DESCRIPTION
**Summary**
This PR completes the "Screen Mirror" tool, which was previously non-functional. It fixes critical connection issues (black screen), adds missing functionality (stop sharing, audio support), and improves the UI/UX.

**Key Changes**
- Fix Connection Handshake: Implemented a "dummy stream" in joinStream() to ensure the WebRTC handshake completes. This fixes the issue where viewers saw a black screen because they weren't sending media back to the host.

- Add "Stop Sharing" Logic: Added a stopSharing() function to properly close MediaStream tracks, end PeerJS calls, and reset the UI without requiring a page refresh.

- Enable Audio: Updated getDisplayMedia constraints to request system audio (audio: true).

**Testing**
- Verified connectivity between two tabs on localhost.

- Confirmed audio and video transmission.

- Verified that clicking "Stop" correctly resets the interface for both Host and Viewer.