### PR TITLE
Improve JSON formatter UX with auto-format on paste and download option

### DIFF
--- a/tools/json-formatter/json-formatter.html
+++ b/tools/json-formatter/json-formatter.html
@@ -216,6 +216,8 @@ a:hover {
                 <button id="minifyBtn">Minify (Compact)</button>
                 <button id="validateBtn">Validate Only</button>
                 <button id="clearBtn">Clear</button>
+                <button id="downloadBtn">Download JSON</button>
+
             </div>
 
             <div id="status"></div>

--- a/tools/json-formatter/json-logic.js
+++ b/tools/json-formatter/json-logic.js
@@ -8,6 +8,8 @@ const minifyBtn = document.getElementById('minifyBtn');
 const validateBtn = document.getElementById('validateBtn');
 const clearBtn = document.getElementById('clearBtn');
 const copyBtn = document.getElementById('copyBtn');
+const downloadBtn = document.getElementById('downloadBtn');
+
 
 function showStatus(message, isError = false) {
     statusDiv.textContent = message;
@@ -65,4 +67,28 @@ copyBtn.onclick = () => {
     setTimeout(() => copyBtn.textContent = originalText, 2000);
 };
 
+downloadBtn.onclick = () => {
+    if (!jsonOutput.value) {
+        showStatus("Nothing to download.", true);
+        return;
+    }
+
+    const blob = new Blob([jsonOutput.value], { type: "application/json" });
+    const url = URL.createObjectURL(blob);
+
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = "data.json";
+    a.click();
+
+    URL.revokeObjectURL(url);
+    showStatus("JSON file downloaded.");
+};
+
+
 jsonInput.addEventListener('input', clearStatus);
+jsonInput.addEventListener('paste', () => {
+    setTimeout(() => {
+        processJSON('format');
+    }, 50);
+});


### PR DESCRIPTION
Fixes #57 
This PR improves the existing JSON Formatter with small but meaningful UX enhancements.

### Changes
- Automatically formats JSON when pasted into the input field
- Allows users to download formatted or minified JSON as a `.json` file

### Why
- Speeds up common workflows
- Reuses existing formatter logic
- No UI redesign or breaking changes

All changes are fully client-side.
