### PR TITLE
back to home added

### DIFF
--- a/tools/audio-trimmer/audio-trimmer.html
+++ b/tools/audio-trimmer/audio-trimmer.html
@@ -190,7 +190,22 @@
             margin-top: 10px;
             display: none;
         }
-
+         .backtohome{
+            height:20vh;
+            width:100%;
+            display: flex;
+            justify-content: flex-start;
+            align-items: center;
+         }
+        .back-home{
+            color: black;
+            margin-top: 10px;
+            text-decoration: none;
+        }
+        a:hover{
+            text-decoration: underline dotted black;
+}
+    
     </style>
 </head>
 <body>
@@ -224,6 +239,9 @@
             <button id="btn-preview" class="secondary">▶ Preview Trim</button>
             <button id="btn-download">💾 Download Trimmed WAV</button>
         </div>
+    </div>
+    <div class="backtohome">
+        <a href="../../index.html" class="back-home">← Back to Home</a>
     </div>
 
     <script src="audio-logic.js"></script>


### PR DESCRIPTION
## Summary
Adds a "← Back to Home" navigation link to the Audio Trimmer page header.

## Related Issue
Closes #168

## Changes
* Added a `← Back to Home` anchor tag linking to `../../index.html` in the header
* Added `.back-home` CSS class for styling the navigation link
* Added hover effect with dotted underline on the link

## Testing
* [ ] Added/updated tests
* [x] Tested locally (describe steps below)

## Testing Steps
1. Open `tools/audio-trimmer/audio-trimmer.html` in a browser
2. Confirm "← Back to Home" link is visible at the top of the page
3. Click the link and confirm it navigates back to the main homepage (`index.html`)
## Contributor Details

* Name: Aditi Jha
* GitHub Username: aditijha509
* Program (SSoC



https://github.com/user-attachments/assets/e2ed67fc-f073-41b3-9ffc-766ecbb0c38c

