### PR TITLE
feat: add IP Subnet Calculator tool

### DIFF
--- a/index.html
+++ b/index.html
@@ -602,6 +602,7 @@ Your work stays yours.</p>
         { name: "Mesh Studio", path: "tools/mesh-studio/mesh_core.html", tags: ["Dev"] },
         { name: "Email Validator", path: "tools/email-validator/email-validator.html", tags: ["Dev", "Utilities"] },
         { name: "CI/CD Visualizer", path: "tools/cicd-visualizer/cicd-visualizer.html", tags: ["Dev", "Design"] },
+        { name: "IP Subnet Calculator", path: "tools/ip-subnet-calculator/index.html", tags: ["Dev", "Utilities"] },
     ];
 
     let activeTag = 'all';

--- a/tools/ip-subnet-calculator/index.html
+++ b/tools/ip-subnet-calculator/index.html
@@ -1,0 +1,249 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>IP Subnet Calculator - Project Toolsuite</title>
+    <meta name="description" content="Offline-first IPv4 subnet calculator. Calculate network ranges, broadcast addresses, usable hosts, binary masks, and subnet metadata.">
+    <link rel="stylesheet" href="../../theme.css">
+    <link rel="stylesheet" href="style.css">
+    <script src="../../theme.js"></script>
+</head>
+<body>
+
+<div class="container">
+    <header>
+        <div class="header-main">
+            <h1>IP Subnet Calculator</h1>
+            <p>Calculate network addresses, host ranges, subnet masks, and binary layouts offline.</p>
+        </div>
+        <button class="dark-mode-toggle" onclick="toggleTheme()" id="themeBtn">
+            <span class="theme-option dark-mode-option hidden">
+                <svg class="theme-icon-dark sun-icon" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="black" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                    <circle cx="12" cy="12" r="5"></circle>
+                    <line x1="12" y1="1" x2="12" y2="3"></line>
+                    <line x1="12" y1="21" x2="12" y2="23"></line>
+                    <line x1="4.22" y1="4.22" x2="5.64" y2="5.64"></line>
+                    <line x1="18.36" y1="18.36" x2="19.78" y2="19.78"></line>
+                    <line x1="1" y1="12" x2="3" y2="12"></line>
+                    <line x1="21" y1="12" x2="23" y2="12"></line>
+                    <line x1="4.22" y1="19.78" x2="5.64" y2="18.36"></line>
+                    <line x1="18.36" y1="5.64" x2="19.78" y2="4.22"></line>
+                </svg>
+                LIGHT MODE
+            </span>
+            <span class="theme-option light-mode-option">
+                <svg class="theme-icon moon-icon" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="white" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                    <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"></path>
+                </svg>
+                DARK MODE
+            </span>
+        </button>
+    </header>
+
+    <main class="calculator-layout">
+        <!-- Input section -->
+        <section class="card input-card">
+            <h2 class="card-title">Subnet Inputs</h2>
+            
+            <div class="form-group">
+                <label for="ipAddress" class="form-label">IPv4 Address</label>
+                <input type="text" id="ipAddress" placeholder="e.g. 192.168.1.10" value="192.168.1.10" autocomplete="off" spellcheck="false">
+                <span class="error-msg" id="ipError"></span>
+            </div>
+
+            <div class="form-group">
+                <label for="cidrPrefix" class="form-label">CIDR Prefix</label>
+                <div class="cidr-input-wrapper">
+                    <span class="cidr-prefix-slash">/</span>
+                    <input type="number" id="cidrPrefix" min="0" max="32" value="24">
+                </div>
+                <span class="error-msg" id="cidrError"></span>
+            </div>
+
+            <div class="form-group">
+                <label class="form-label">CIDR Range Slider</label>
+                <input type="range" id="cidrSlider" min="0" max="32" value="24" class="slider-control">
+            </div>
+
+            <div class="form-group">
+                <label class="form-label">Quick Presets</label>
+                <div class="presets-container">
+                    <button type="button" class="preset-btn" data-value="8">/8 (Class A)</button>
+                    <button type="button" class="preset-btn" data-value="16">/16 (Class B)</button>
+                    <button type="button" class="preset-btn" data-value="24">/24 (Class C)</button>
+                    <button type="button" class="preset-btn" data-value="30">/30 (P2P)</button>
+                    <button type="button" class="preset-btn" data-value="32">/32 (Host)</button>
+                </div>
+            </div>
+
+            <button type="button" id="calculateBtn" class="action-btn">Calculate Subnet</button>
+        </section>
+
+        <!-- Output section -->
+        <div class="results-column">
+            <!-- Summary Results Card -->
+            <section class="card results-card" id="resultsCard">
+                <h2 class="card-title">Calculated Subnet Details</h2>
+                
+                <div class="results-grid">
+                    <div class="result-item">
+                        <span class="result-label">Network Address</span>
+                        <div class="result-value-wrapper">
+                            <span id="resNetwork" class="result-value">192.168.1.0</span>
+                            <button class="copy-btn" title="Copy to clipboard" data-target="resNetwork">
+                                <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="9" y="9" width="13" height="13" rx="2" ry="2"></rect><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"></path></svg>
+                            </button>
+                        </div>
+                    </div>
+
+                    <div class="result-item">
+                        <span class="result-label">Broadcast Address</span>
+                        <div class="result-value-wrapper">
+                            <span id="resBroadcast" class="result-value">192.168.1.255</span>
+                            <button class="copy-btn" title="Copy to clipboard" data-target="resBroadcast">
+                                <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="9" y="9" width="13" height="13" rx="2" ry="2"></rect><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"></path></svg>
+                            </button>
+                        </div>
+                    </div>
+
+                    <div class="result-item">
+                        <span class="result-label">First Usable Host</span>
+                        <div class="result-value-wrapper">
+                            <span id="resFirstHost" class="result-value">192.168.1.1</span>
+                            <button class="copy-btn" title="Copy to clipboard" data-target="resFirstHost">
+                                <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="9" y="9" width="13" height="13" rx="2" ry="2"></rect><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"></path></svg>
+                            </button>
+                        </div>
+                    </div>
+
+                    <div class="result-item">
+                        <span class="result-label">Last Usable Host</span>
+                        <div class="result-value-wrapper">
+                            <span id="resLastHost" class="result-value">192.168.1.254</span>
+                            <button class="copy-btn" title="Copy to clipboard" data-target="resLastHost">
+                                <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="9" y="9" width="13" height="13" rx="2" ry="2"></rect><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"></path></svg>
+                            </button>
+                        </div>
+                    </div>
+
+                    <div class="result-item">
+                        <span class="result-label">Subnet Mask</span>
+                        <div class="result-value-wrapper">
+                            <span id="resSubnetMask" class="result-value">255.255.255.0</span>
+                            <button class="copy-btn" title="Copy to clipboard" data-target="resSubnetMask">
+                                <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="9" y="9" width="13" height="13" rx="2" ry="2"></rect><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"></path></svg>
+                            </button>
+                        </div>
+                    </div>
+
+                    <div class="result-item">
+                        <span class="result-label">CIDR Prefix</span>
+                        <div class="result-value-wrapper">
+                            <span id="resCidr" class="result-value">/24</span>
+                            <button class="copy-btn" title="Copy to clipboard" data-target="resCidr">
+                                <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="9" y="9" width="13" height="13" rx="2" ry="2"></rect><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"></path></svg>
+                            </button>
+                        </div>
+                    </div>
+
+                    <div class="result-item">
+                        <span class="result-label">Total Addresses</span>
+                        <div class="result-value-wrapper">
+                            <span id="resTotalHosts" class="result-value">256</span>
+                            <button class="copy-btn" title="Copy to clipboard" data-target="resTotalHosts">
+                                <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="9" y="9" width="13" height="13" rx="2" ry="2"></rect><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"></path></svg>
+                            </button>
+                        </div>
+                    </div>
+
+                    <div class="result-item">
+                        <span class="result-label">Usable Hosts</span>
+                        <div class="result-value-wrapper">
+                            <span id="resUsableHosts" class="result-value">254</span>
+                            <button class="copy-btn" title="Copy to clipboard" data-target="resUsableHosts">
+                                <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="9" y="9" width="13" height="13" rx="2" ry="2"></rect><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"></path></svg>
+                            </button>
+                        </div>
+                    </div>
+                </div>
+            </section>
+
+            <!-- Metadata Cards (Class & Designation) -->
+            <section class="card meta-card" id="metaCard">
+                <h2 class="card-title">Network Info & Properties</h2>
+                <div class="meta-grid">
+                    <div class="meta-item">
+                        <span class="meta-label">IP Class</span>
+                        <span id="metaClass" class="meta-value-badge class-c">Class C</span>
+                    </div>
+                    <div class="meta-item">
+                        <span class="meta-label">Network Type</span>
+                        <span id="metaScope" class="meta-value-badge type-private">Private (RFC 1918)</span>
+                    </div>
+                    <div class="meta-item full-width">
+                        <span class="meta-label">Details</span>
+                        <span id="metaDescription" class="meta-value-text">Commonly used for local area networks (LANs). Not routable on the public Internet.</span>
+                    </div>
+                </div>
+            </section>
+
+            <!-- Special Networks explanation box (dynamically shown or tailored) -->
+            <section class="card edge-case-card hidden" id="edgeCaseCard">
+                <h2 class="card-title info-title">
+                    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"></circle><line x1="12" y1="16" x2="12" y2="12"></line><line x1="12" y1="8" x2="12.01" y2="8"></line></svg>
+                    Special Network Node
+                </h2>
+                <p id="edgeCaseExplanation" class="edge-explanation-text">
+                    For /31 networks, RFC 3021 applies. Standard network and broadcast addresses are eliminated, making both addresses usable hosts for point-to-point links.
+                </p>
+            </section>
+
+            <!-- Binary Visualization -->
+            <section class="card binary-card" id="binaryCard">
+                <h2 class="card-title">Subnet Binary Breakdown</h2>
+                <div class="binary-visualizer">
+                    <div class="binary-row">
+                        <span class="binary-label">IP Address:</span>
+                        <div class="binary-octets" id="binIp">
+                            <span>11000000</span>.<span>10101000</span>.<span>00000001</span>.<span>00001010</span>
+                        </div>
+                    </div>
+                    <div class="binary-row">
+                        <span class="binary-label">Subnet Mask:</span>
+                        <div class="binary-octets" id="binMask">
+                            <span class="mask-bits">11111111</span>.<span class="mask-bits">11111111</span>.<span class="mask-bits">11111111</span>.<span class="host-bits">00000000</span>
+                        </div>
+                    </div>
+                    <div class="binary-row divider-row"></div>
+                    <div class="binary-row">
+                        <span class="binary-label">Network Address:</span>
+                        <div class="binary-octets" id="binNetwork">
+                            <span>11000000</span>.<span>10101000</span>.<span>00000001</span>.<span>00000000</span>
+                        </div>
+                    </div>
+                    <div class="binary-row">
+                        <span class="binary-label">Broadcast Address:</span>
+                        <div class="binary-octets" id="binBroadcast">
+                            <span>11000000</span>.<span>10101000</span>.<span>00000001</span>.<span>11111111</span>
+                        </div>
+                    </div>
+                </div>
+                <div class="binary-legend">
+                    <div class="legend-item"><span class="legend-box mask-bits"></span> Subnet Part</div>
+                    <div class="legend-item"><span class="legend-box host-bits"></span> Host Part</div>
+                </div>
+            </section>
+        </div>
+    </main>
+
+    <footer>
+        <a href="../../index.html">&larr; Back to Home</a>
+    </footer>
+</div>
+
+<div id="copyToast" class="toast hidden">Copied to clipboard!</div>
+
+<script src="script.js"></script>
+</body>
+</html>

--- a/tools/ip-subnet-calculator/script.js
+++ b/tools/ip-subnet-calculator/script.js
@@ -1,0 +1,417 @@
+/**
+ * IP Subnet Calculator - script.js
+ * Client-side IPv4 subnet calculations and formatting.
+ */
+
+document.addEventListener('DOMContentLoaded', () => {
+    // DOM Elements
+    const ipInput = document.getElementById('ipAddress');
+    const cidrInput = document.getElementById('cidrPrefix');
+    const cidrSlider = document.getElementById('cidrSlider');
+    const calculateBtn = document.getElementById('calculateBtn');
+    const presetBtns = document.querySelectorAll('.preset-btn');
+    
+    // Error elements
+    const ipError = document.getElementById('ipError');
+    const cidrError = document.getElementById('cidrError');
+    
+    // Result elements
+    const resNetwork = document.getElementById('resNetwork');
+    const resBroadcast = document.getElementById('resBroadcast');
+    const resFirstHost = document.getElementById('resFirstHost');
+    const resLastHost = document.getElementById('resLastHost');
+    const resSubnetMask = document.getElementById('resSubnetMask');
+    const resCidr = document.getElementById('resCidr');
+    const resTotalHosts = document.getElementById('resTotalHosts');
+    const resUsableHosts = document.getElementById('resUsableHosts');
+    
+    // Metadata elements
+    const metaClass = document.getElementById('metaClass');
+    const metaScope = document.getElementById('metaScope');
+    const metaDescription = document.getElementById('metaDescription');
+    const edgeCaseCard = document.getElementById('edgeCaseCard');
+    const edgeCaseExplanation = document.getElementById('edgeCaseExplanation');
+    
+    // Binary elements
+    const binIp = document.getElementById('binIp');
+    const binMask = document.getElementById('binMask');
+    const binNetwork = document.getElementById('binNetwork');
+    const binBroadcast = document.getElementById('binBroadcast');
+    
+    // Toast element
+    const copyToast = document.getElementById('copyToast');
+
+    // REGEX for IPv4 Address Validation
+    const ipRegex = /^((25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$/;
+
+    // Initialize Calculator
+    calculateSubnet();
+
+    // Event Listeners for sync inputs
+    cidrInput.addEventListener('input', (e) => {
+        const val = parseInt(e.target.value, 10);
+        if (!isNaN(val) && val >= 0 && val <= 32) {
+            cidrSlider.value = val;
+            clearError(cidrError);
+            updatePresetActiveState(val);
+            calculateSubnet();
+        } else {
+            showError(cidrError, 'Must be between 0 and 32');
+        }
+    });
+
+    cidrSlider.addEventListener('input', (e) => {
+        const val = parseInt(e.target.value, 10);
+        cidrInput.value = val;
+        clearError(cidrError);
+        updatePresetActiveState(val);
+        calculateSubnet();
+    });
+
+    ipInput.addEventListener('input', () => {
+        const ip = ipInput.value.trim();
+        if (ipRegex.test(ip)) {
+            clearError(ipError);
+            calculateSubnet();
+        }
+    });
+
+    // Preset buttons
+    presetBtns.forEach(btn => {
+        btn.addEventListener('click', () => {
+            const val = parseInt(btn.getAttribute('data-value'), 10);
+            cidrInput.value = val;
+            cidrSlider.value = val;
+            clearError(cidrError);
+            updatePresetActiveState(val);
+            calculateSubnet();
+        });
+    });
+
+    // Explicit Calculate button
+    calculateBtn.addEventListener('click', () => {
+        const isIpValid = validateIp();
+        const isCidrValid = validateCidr();
+        
+        if (isIpValid && isCidrValid) {
+            calculateSubnet();
+        }
+    });
+
+    // Enter Key on Inputs triggers calculation
+    ipInput.addEventListener('keypress', (e) => {
+        if (e.key === 'Enter') {
+            calculateBtn.click();
+        }
+    });
+
+    cidrInput.addEventListener('keypress', (e) => {
+        if (e.key === 'Enter') {
+            calculateBtn.click();
+        }
+    });
+
+    // Copy to clipboard setup
+    document.querySelectorAll('.copy-btn').forEach(btn => {
+        btn.addEventListener('click', () => {
+            const targetId = btn.getAttribute('data-target');
+            const targetEl = document.getElementById(targetId);
+            if (targetEl) {
+                const textToCopy = targetEl.textContent.trim();
+                navigator.clipboard.writeText(textToCopy)
+                    .then(() => showToast(`Copied: ${textToCopy}`))
+                    .catch(() => showToast('Failed to copy text'));
+            }
+        });
+    });
+
+    /**
+     * Set active class on active preset button
+     */
+    function updatePresetActiveState(cidr) {
+        presetBtns.forEach(btn => {
+            const val = parseInt(btn.getAttribute('data-value'), 10);
+            if (val === cidr) {
+                btn.classList.add('active');
+            } else {
+                btn.classList.remove('active');
+            }
+        });
+    }
+
+    /**
+     * Input Validation Helpers
+     */
+    function validateIp() {
+        const ip = ipInput.value.trim();
+        if (!ip) {
+            showError(ipError, 'IP Address cannot be empty');
+            return false;
+        }
+        if (!ipRegex.test(ip)) {
+            showError(ipError, 'Invalid IPv4 address format (e.g. 192.168.1.1)');
+            return false;
+        }
+        clearError(ipError);
+        return true;
+    }
+
+    function validateCidr() {
+        const val = parseInt(cidrInput.value, 10);
+        if (isNaN(val) || val < 0 || val > 32) {
+            showError(cidrError, 'CIDR Prefix must be an integer between 0 and 32');
+            return false;
+        }
+        clearError(cidrError);
+        return true;
+    }
+
+    function showError(element, msg) {
+        element.textContent = msg;
+    }
+
+    function clearError(element) {
+        element.textContent = '';
+    }
+
+    /**
+     * Subnet Math and Execution
+     */
+    function calculateSubnet() {
+        const ipStr = ipInput.value.trim();
+        const cidrVal = parseInt(cidrInput.value, 10);
+
+        // Simple validation checks before computing
+        if (!ipRegex.test(ipStr) || isNaN(cidrVal) || cidrVal < 0 || cidrVal > 32) {
+            return;
+        }
+
+        // Convert IP to integer representation
+        const ipInt = ipToInt(ipStr);
+
+        // Calculate Mask
+        // Shift bits in JS works on 32-bit signed ints. Masking with >>> 0 forces unsigned.
+        const maskInt = cidrVal === 0 ? 0 : (0xffffffff << (32 - cidrVal)) >>> 0;
+        const wildcardInt = maskInt ^ 0xffffffff;
+
+        // Calculate Network and Broadcast Addresses
+        const networkInt = (ipInt & maskInt) >>> 0;
+        const broadcastInt = cidrVal === 32 ? networkInt : (networkInt | wildcardInt) >>> 0;
+
+        // Convert back to dot-decimal strings
+        const networkStr = intToIp(networkInt);
+        const broadcastStr = intToIp(broadcastInt);
+        const maskStr = intToIp(maskInt);
+
+        // Calculate host boundaries & counts
+        let firstHostInt, lastHostInt, totalHosts, usableHosts;
+
+        if (cidrVal === 32) {
+            // Single IP Host case
+            firstHostInt = networkInt;
+            lastHostInt = networkInt;
+            totalHosts = 1;
+            usableHosts = 1;
+            
+            showEdgeCaseCard(32);
+        } else if (cidrVal === 31) {
+            // Point-to-Point links case (RFC 3021)
+            firstHostInt = networkInt;
+            lastHostInt = broadcastInt;
+            totalHosts = 2;
+            usableHosts = 2;
+            
+            showEdgeCaseCard(31);
+        } else {
+            // Standard subnet cases
+            firstHostInt = networkInt + 1;
+            lastHostInt = broadcastInt - 1;
+            totalHosts = Math.pow(2, 32 - cidrVal);
+            usableHosts = totalHosts - 2;
+            
+            hideEdgeCaseCard();
+        }
+
+        const firstHostStr = intToIp(firstHostInt);
+        const lastHostStr = intToIp(lastHostInt);
+
+        // Populate results fields in UI
+        resNetwork.textContent = networkStr;
+        resBroadcast.textContent = broadcastStr;
+        resFirstHost.textContent = firstHostStr;
+        resLastHost.textContent = lastHostStr;
+        resSubnetMask.textContent = maskStr;
+        resCidr.textContent = `/${cidrVal}`;
+        resTotalHosts.textContent = totalHosts.toLocaleString();
+        resUsableHosts.textContent = usableHosts.toLocaleString();
+
+        // Populate Binary breakdowns with highlighted subnet vs host bits
+        binIp.innerHTML = getBinaryHtmlWithLegend(ipInt, cidrVal);
+        binMask.innerHTML = getBinaryHtmlWithLegend(maskInt, cidrVal);
+        binNetwork.innerHTML = getBinaryHtmlWithLegend(networkInt, cidrVal);
+        binBroadcast.innerHTML = getBinaryHtmlWithLegend(broadcastInt, cidrVal);
+
+        // Update properties and Class designations
+        updateIpMetadata(ipStr, ipInt);
+    }
+
+    /**
+     * Conversion helpers
+     */
+    function ipToInt(ipStr) {
+        const parts = ipStr.split('.').map(Number);
+        return ((parts[0] << 24) | (parts[1] << 16) | (parts[2] << 8) | parts[3]) >>> 0;
+    }
+
+    function intToIp(intVal) {
+        return [
+            (intVal >>> 24) & 255,
+            (intVal >>> 16) & 255,
+            (intVal >>> 8) & 255,
+            intVal & 255
+        ].join('.');
+    }
+
+    /**
+     * Binary Highlight Generator
+     */
+    function getBinaryHtmlWithLegend(intVal, cidr) {
+        const binary = (intVal >>> 0).toString(2).padStart(32, '0');
+        let html = '';
+        for (let i = 0; i < 32; i++) {
+            if (i > 0 && i % 8 === 0) {
+                html += '.';
+            }
+            const bit = binary[i];
+            if (i < cidr) {
+                html += `<span class="mask-bits">${bit}</span>`;
+            } else {
+                html += `<span class="host-bits">${bit}</span>`;
+            }
+        }
+        return html;
+    }
+
+    /**
+     * Determines IP Class and Subnet Type and binds description to UI
+     */
+    function updateIpMetadata(ipStr, ipInt) {
+        const firstOctet = parseInt(ipStr.split('.')[0], 10);
+        const secondOctet = parseInt(ipStr.split('.')[1], 10);
+        
+        let ipClass = 'Unknown';
+        let classCss = 'class-e';
+        let ipScope = 'Public';
+        let scopeCss = 'type-public';
+        let description = 'Routable public IP address on the global Internet.';
+
+        // 1. IP Class Determination
+        if (firstOctet >= 0 && firstOctet <= 127) {
+            ipClass = 'Class A';
+            classCss = 'class-a';
+        } else if (firstOctet >= 128 && firstOctet <= 191) {
+            ipClass = 'Class B';
+            classCss = 'class-b';
+        } else if (firstOctet >= 192 && firstOctet <= 223) {
+            ipClass = 'Class C';
+            classCss = 'class-c';
+        } else if (firstOctet >= 224 && firstOctet <= 239) {
+            ipClass = 'Class D (Multicast)';
+            classCss = 'class-d';
+            ipScope = 'Multicast';
+            scopeCss = 'type-special';
+            description = 'Used for one-to-many multicast messaging. Not assigned to individual host devices.';
+        } else if (firstOctet >= 240 && firstOctet <= 255) {
+            ipClass = 'Class E (Reserved)';
+            classCss = 'class-e';
+            ipScope = 'Reserved';
+            scopeCss = 'type-special';
+            description = 'Reserved by the IETF for experimental, research, or future administrative use.';
+        }
+
+        // 2. IP Range/Scope Determination (Overriding description/scope if matched)
+        if (ipClass !== 'Class D (Multicast)' && ipClass !== 'Class E (Reserved)') {
+            // Private network check (RFC 1918)
+            if (firstOctet === 10) {
+                ipScope = 'Private (RFC 1918)';
+                scopeCss = 'type-private';
+                description = 'Used for private intranets. Non-routable on the public Internet. Free to configure locally.';
+            } else if (firstOctet === 172 && (secondOctet >= 16 && secondOctet <= 31)) {
+                ipScope = 'Private (RFC 1918)';
+                scopeCss = 'type-private';
+                description = 'Used for private intranets. Non-routable on the public Internet. Free to configure locally.';
+            } else if (firstOctet === 192 && secondOctet === 168) {
+                ipScope = 'Private (RFC 1918)';
+                scopeCss = 'type-private';
+                description = 'Used for private intranets. Non-routable on the public Internet. Free to configure locally.';
+            }
+            // Loopback check
+            else if (firstOctet === 127) {
+                ipScope = 'Loopback';
+                scopeCss = 'type-loopback';
+                description = 'Special loopback range. Used for testing network software on the local host machine itself.';
+            }
+            // Link-Local / APIPA
+            else if (firstOctet === 169 && secondOctet === 254) {
+                ipScope = 'Link-Local (APIPA)';
+                scopeCss = 'type-special';
+                description = 'Automatic Private IP Addressing. Assigned locally when a host fails to receive an IP from a DHCP server.';
+            }
+            // Carrier-Grade NAT (RFC 6598)
+            else if (firstOctet === 100 && (secondOctet >= 64 && secondOctet <= 127)) {
+                ipScope = 'Shared CGNAT';
+                scopeCss = 'type-special';
+                description = 'Carrier-Grade NAT range. Used by ISPs to conserve public IPv4 addresses for consumer routing.';
+            }
+            // Documentation Test Networks (RFC 5737)
+            else if (
+                (firstOctet === 192 && secondOctet === 0 && parseInt(ipStr.split('.')[2], 10) === 2) ||
+                (firstOctet === 198 && secondOctet === 51 && parseInt(ipStr.split('.')[2], 10) === 100) ||
+                (firstOctet === 203 && secondOctet === 0 && parseInt(ipStr.split('.')[2], 10) === 113)
+            ) {
+                ipScope = 'Documentation';
+                scopeCss = 'type-special';
+                description = 'TEST-NET ranges reserved exclusively for tutorials, documentation, and example configurations.';
+            }
+        }
+
+        // Apply metadata designations to elements
+        metaClass.textContent = ipClass;
+        metaClass.className = `meta-value-badge ${classCss}`;
+        
+        metaScope.textContent = ipScope;
+        metaScope.className = `meta-value-badge ${scopeCss}`;
+        
+        metaDescription.textContent = description;
+    }
+
+    /**
+     * Info display for edge-cases
+     */
+    function showEdgeCaseCard(cidr) {
+        edgeCaseCard.classList.remove('hidden');
+        if (cidr === 32) {
+            edgeCaseExplanation.innerHTML = `<strong>/32 Subnet: Single Host.</strong> In a /32 network, there is only 1 address. The network, broadcast, and host address are all the same. There are no dedicated network or broadcast boundaries.`;
+        } else if (cidr === 31) {
+            edgeCaseExplanation.innerHTML = `<strong>/31 Subnet: Point-to-Point (RFC 3021).</strong> In a /31 network, there are exactly 2 addresses. To prevent wasting 50% of the addresses on point-to-point links, RFC 3021 removes the network and broadcast address restrictions, allowing both IP addresses to be fully usable host addresses.`;
+        }
+    }
+
+    function hideEdgeCaseCard() {
+        edgeCaseCard.classList.add('hidden');
+    }
+
+    /**
+     * Clipboard Toast Alert
+     */
+    let toastTimeout;
+    function showToast(msg) {
+        copyToast.textContent = msg;
+        copyToast.classList.remove('hidden');
+        
+        clearTimeout(toastTimeout);
+        toastTimeout = setTimeout(() => {
+            copyToast.classList.add('hidden');
+        }, 2000);
+    }
+});

--- a/tools/ip-subnet-calculator/style.css
+++ b/tools/ip-subnet-calculator/style.css
@@ -1,0 +1,529 @@
+/* IP Subnet Calculator Specific Styles */
+
+:root {
+    --subnet-color: #22c55e;
+    --host-color: #3b82f6;
+    --card-bg: var(--bg);
+}
+
+body {
+    font-family: 'Courier New', Courier, monospace;
+    background-color: var(--bg);
+    color: var(--text);
+    line-height: 1.7;
+    margin: 0;
+    padding: 0;
+    transition: background-color 0.3s, color 0.3s;
+}
+
+.container {
+    max-width: 1100px;
+    margin: 0 auto;
+    padding: 48px 28px;
+}
+
+header {
+    border-bottom: 5px solid var(--border);
+    padding-bottom: 28px;
+    margin-bottom: 40px;
+    position: relative;
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+    flex-wrap: wrap;
+    gap: 20px;
+}
+
+.header-main {
+    flex: 1;
+    min-width: 280px;
+}
+
+h1 {
+    font-size: 2.4rem;
+    text-transform: uppercase;
+    margin: 0 0 12px;
+    letter-spacing: 0.04em;
+}
+
+header p {
+    margin: 0;
+    opacity: 0.8;
+    font-size: 1rem;
+}
+
+/* Base Card Styling */
+.card {
+    border: 3px solid var(--border);
+    padding: 24px;
+    margin-bottom: 24px;
+    background: var(--card-bg);
+    box-shadow: 6px 6px 0px var(--border);
+    transition: transform 0.2s, box-shadow 0.2s;
+}
+
+.card-title {
+    margin-top: 0;
+    margin-bottom: 20px;
+    font-size: 1.3rem;
+    text-transform: uppercase;
+    border-bottom: 3px solid var(--border);
+    padding-bottom: 8px;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+}
+
+/* Calculator Grid Layout */
+.calculator-layout {
+    display: grid;
+    grid-template-columns: 380px 1fr;
+    gap: 32px;
+    align-items: start;
+}
+
+/* Form Controls */
+.form-group {
+    margin-bottom: 20px;
+}
+
+.form-label {
+    display: block;
+    font-weight: 900;
+    text-transform: uppercase;
+    margin-bottom: 8px;
+    font-size: 0.9rem;
+}
+
+input[type="text"],
+input[type="number"] {
+    width: 100%;
+    padding: 12px;
+    font-family: inherit;
+    font-size: 1.1rem;
+    border: 3px solid var(--border);
+    background: transparent;
+    color: inherit;
+    box-sizing: border-box;
+    outline: none;
+    transition: background-color 0.2s;
+}
+
+input[type="text"]:focus,
+input[type="number"]:focus {
+    background: var(--tag-bg);
+}
+
+.cidr-input-wrapper {
+    display: flex;
+    align-items: center;
+    border: 3px solid var(--border);
+}
+
+.cidr-prefix-slash {
+    font-weight: 900;
+    font-size: 1.2rem;
+    padding: 0 12px;
+    background: var(--tag-bg);
+    border-right: 3px solid var(--border);
+    height: 100%;
+    display: flex;
+    align-items: center;
+    user-select: none;
+}
+
+.cidr-input-wrapper input[type="number"] {
+    border: none;
+    flex-grow: 1;
+}
+
+/* Slider Custom Styling */
+.slider-control {
+    -webkit-appearance: none;
+    appearance: none;
+    width: 100%;
+    height: 10px;
+    border: 2px solid var(--border);
+    background: var(--tag-bg);
+    outline: none;
+    margin: 12px 0;
+}
+
+.slider-control::-webkit-slider-thumb {
+    -webkit-appearance: none;
+    appearance: none;
+    width: 20px;
+    height: 20px;
+    border: 2px solid var(--border);
+    background: var(--text);
+    cursor: pointer;
+    transition: transform 0.1s;
+}
+
+.slider-control::-webkit-slider-thumb:active {
+    transform: scale(1.2);
+}
+
+/* Quick presets buttons */
+.presets-container {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(65px, 1fr));
+    gap: 8px;
+    margin-top: 8px;
+}
+
+.preset-btn {
+    padding: 6px 4px;
+    font-family: inherit;
+    font-size: 0.75rem;
+    font-weight: bold;
+    border: 2px solid var(--border);
+    background: var(--tag-bg);
+    color: var(--text);
+    cursor: pointer;
+    transition: all 0.1s;
+    text-align: center;
+}
+
+.preset-btn:hover {
+    background: var(--text);
+    color: var(--bg);
+}
+
+.preset-btn.active {
+    background: var(--text);
+    color: var(--bg);
+}
+
+/* Action Button */
+.action-btn {
+    width: 100%;
+    padding: 14px;
+    font-family: inherit;
+    font-size: 1.1rem;
+    font-weight: bold;
+    background: var(--text);
+    color: var(--bg);
+    border: 3px solid var(--border);
+    cursor: pointer;
+    text-transform: uppercase;
+    box-shadow: 4px 4px 0px var(--border);
+    transition: transform 0.1s, box-shadow 0.1s;
+    margin-top: 10px;
+}
+
+.action-btn:active {
+    transform: translate(2px, 2px);
+    box-shadow: 2px 2px 0px var(--border);
+}
+
+/* Errors */
+.error-msg {
+    color: #ff4d4d;
+    font-size: 0.8rem;
+    display: block;
+    margin-top: 6px;
+    min-height: 1.2em;
+    font-weight: bold;
+}
+
+/* Results section */
+.results-column {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+
+.results-grid {
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
+    gap: 16px;
+}
+
+.result-item {
+    border: 2px solid var(--border);
+    padding: 12px;
+    background: var(--tag-bg);
+}
+
+.result-label {
+    display: block;
+    font-size: 0.75rem;
+    text-transform: uppercase;
+    opacity: 0.7;
+    font-weight: bold;
+    margin-bottom: 4px;
+}
+
+.result-value-wrapper {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 8px;
+}
+
+.result-value {
+    font-size: 1.1rem;
+    font-weight: bold;
+    word-break: break-all;
+}
+
+/* Copy Buttons */
+.copy-btn {
+    background: transparent;
+    border: none;
+    color: var(--text);
+    cursor: pointer;
+    padding: 4px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border: 1px solid transparent;
+    transition: all 0.1s;
+}
+
+.copy-btn:hover {
+    border-color: var(--border);
+    background: var(--bg);
+}
+
+.copy-btn:active {
+    transform: scale(0.9);
+}
+
+/* Metadata properties */
+.meta-grid {
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
+    gap: 16px;
+}
+
+.meta-item {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+}
+
+.meta-item.full-width {
+    grid-column: 1 / -1;
+}
+
+.meta-label {
+    font-size: 0.75rem;
+    text-transform: uppercase;
+    opacity: 0.7;
+    font-weight: bold;
+}
+
+.meta-value-badge {
+    padding: 6px 12px;
+    border: 2px solid var(--border);
+    font-weight: bold;
+    text-transform: uppercase;
+    text-align: center;
+    display: inline-block;
+    width: fit-content;
+}
+
+.meta-value-text {
+    font-size: 0.85rem;
+}
+
+/* Class Badges */
+.class-a { background-color: #3b82f6; color: white; }
+.class-b { background-color: #8b5cf6; color: white; }
+.class-c { background-color: #ec4899; color: white; }
+.class-d { background-color: #f59e0b; color: black; }
+.class-e { background-color: #6b7280; color: white; }
+
+/* Network type Badges */
+.type-private { background-color: #10b981; color: white; }
+.type-public { background-color: #6366f1; color: white; }
+.type-loopback { background-color: #ef4444; color: white; }
+.type-special { background-color: #14b8a6; color: white; }
+
+/* Edge Case Explanation Card */
+.edge-case-card {
+    background-color: #fef3c7;
+    color: #92400e;
+    border-color: #f59e0b;
+}
+
+.edge-case-card .card-title {
+    color: #92400e;
+    border-bottom-color: #f59e0b;
+}
+
+.info-title svg {
+    vertical-align: middle;
+}
+
+.edge-explanation-text {
+    margin: 0;
+    font-size: 0.9rem;
+    line-height: 1.6;
+}
+
+/* Dark mode adjustments for Edge Case Card */
+body.dark-mode .edge-case-card {
+    background-color: #78350f;
+    color: #fef3c7;
+    border-color: #f59e0b;
+}
+body.dark-mode .edge-case-card .card-title {
+    color: #fef3c7;
+    border-bottom-color: #f59e0b;
+}
+
+/* Binary visualizer */
+.binary-visualizer {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    font-family: inherit;
+    background: var(--tag-bg);
+    border: 2px solid var(--border);
+    padding: 16px;
+    overflow-x: auto;
+}
+
+.binary-row {
+    display: flex;
+    align-items: center;
+    gap: 16px;
+    white-space: nowrap;
+    min-width: 480px;
+}
+
+.binary-label {
+    width: 150px;
+    font-size: 0.8rem;
+    text-transform: uppercase;
+    font-weight: bold;
+    opacity: 0.8;
+}
+
+.binary-octets {
+    font-size: 1rem;
+    font-weight: bold;
+    letter-spacing: 0.05em;
+}
+
+.binary-octets span {
+    padding: 2px 4px;
+}
+
+.mask-bits {
+    background-color: rgba(34, 197, 94, 0.25);
+    color: var(--subnet-color);
+    border-bottom: 2px solid var(--subnet-color);
+}
+
+.host-bits {
+    background-color: rgba(59, 130, 246, 0.25);
+    color: var(--host-color);
+    border-bottom: 2px solid var(--host-color);
+}
+
+.divider-row {
+    height: 2px;
+    background: var(--border);
+    margin: 4px 0;
+}
+
+.binary-legend {
+    display: flex;
+    gap: 24px;
+    margin-top: 12px;
+    font-size: 0.8rem;
+    font-weight: bold;
+}
+
+.legend-item {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+}
+
+.legend-box {
+    width: 14px;
+    height: 14px;
+    display: inline-block;
+    border: 1px solid var(--border);
+}
+
+/* Toast alert */
+.toast {
+    position: fixed;
+    bottom: 24px;
+    right: 24px;
+    background: var(--text);
+    color: var(--bg);
+    border: 3px solid var(--border);
+    padding: 12px 24px;
+    font-weight: bold;
+    text-transform: uppercase;
+    box-shadow: 4px 4px 0px var(--border);
+    z-index: 1000;
+    transition: opacity 0.3s, transform 0.3s;
+}
+
+.hidden {
+    display: none !important;
+}
+
+/* Footer link formatting */
+footer {
+    margin-top: 40px;
+    padding-top: 24px;
+    border-top: 3px solid var(--border);
+}
+
+footer a {
+    color: var(--text);
+    text-decoration: none;
+    font-weight: bold;
+    text-transform: uppercase;
+    border: 2px solid var(--border);
+    padding: 8px 16px;
+    background: var(--tag-bg);
+    display: inline-block;
+    transition: transform 0.1s;
+}
+
+footer a:hover {
+    transform: translate(-2px, -2px);
+    box-shadow: 4px 4px 0px var(--border);
+}
+
+/* Responsive adjustment */
+@media (max-width: 900px) {
+    .calculator-layout {
+        grid-template-columns: 1fr;
+    }
+    .results-grid {
+        grid-template-columns: 1fr;
+    }
+}
+
+@media (max-width: 500px) {
+    .container {
+        padding: 24px 12px;
+    }
+    h1 {
+        font-size: 1.8rem;
+    }
+    .binary-row {
+        flex-direction: column;
+        align-items: flex-start;
+        gap: 4px;
+        border-bottom: 1px dashed var(--border);
+        padding-bottom: 8px;
+    }
+    .binary-row.divider-row {
+        display: none;
+    }
+    .binary-label {
+        width: auto;
+    }
+}


### PR DESCRIPTION
## Related Issue

Closes #78 



## Changes

* Added a new IP Subnet Calculator utility
* Added IPv4 subnet calculations using CIDR notation
* Added Network Address, Broadcast Address, First Host, and Last Host calculations
* Added Subnet Mask, Total Addresses, and Usable Hosts calculations
* Added input validation for IPv4 addresses and CIDR prefixes
* Added support for /31 and /32 edge cases
* Added binary breakdown visualization
* Added IP Class and IP Type detection
* Added copy-to-clipboard functionality
* Added homepage integration for the new tool

## Testing

* [x] Tested locally (describe steps below)

## Testing Steps

1. Tested with 192.168.1.10/24 and verified network, broadcast, host range, and host counts.
2. Tested with 10.0.5.120/31 and verified RFC 3021 behavior.
3. Tested with 172.16.0.5/32 and verified single-host behavior.
4. Tested invalid IPv4 addresses and invalid CIDR values.
5. Verified dark/light theme compatibility.
6. Verified copy buttons and responsive layout.

## Contributor Details

* Name: Shreya Gupta
* GitHub Username: shreyagupta2006
* Program: SSoC

## Checklist before requesting a review

* [x] Code follows the project's conventions
* [x] No secrets or `.env` values are committed
* [x] I have performed a self-review of my code
* [x] Documentation has been updated if needed
* [ ] CI passes
* [x] Linked the related issue above


