### PR TITLE
fix: add missing tools to homepage registry

### DIFF
--- a/index.html
+++ b/index.html
@@ -928,6 +928,21 @@
           path: "tools/cicd-visualizer/cicd-visualizer.html",
           tags: ["Dev", "Design"],
         },
+        {
+          name: "IP Subnet Calculator",
+          path: "tools/ip-subnet-calculator/index.html",
+          tags: ["Dev", "Utilities"],
+        },
+        {
+          name: "RSA Encryption & Decryption",
+          path: "tools/rsa-encryption-decryption/rsa.html",
+          tags: ["Security", "Dev"],
+        },
+        {
+          name: "Unit Converter",
+          path: "tools/unit-converter/unit-converter.html",
+          tags: ["Utilities", "Maths"],
+        },
       ];
 
       let activeTag = "all";


### PR DESCRIPTION
## Summary

Adds three implemented but unregistered tools to the homepage tool registry.

The following tools were already present in the repository and accessible through direct URLs, but were missing from the homepage tools array:

* IP Subnet Calculator
* RSA Encryption & Decryption
* Unit Converter

## Changes

* Added missing tool definitions to the homepage tools registry in `index.html`
* Verified all three tools appear in homepage search results
* Verified the homepage tool count increases from 46 to 49
* Verified each tool opens correctly from the homepage

Fixes #189
