### PR TITLE
fix: use theme text color for audio trimmer back link

### DIFF
--- a/tools/audio-trimmer/audio-trimmer.html
+++ b/tools/audio-trimmer/audio-trimmer.html
@@ -199,7 +199,7 @@
             align-items: center;
          }
         .back-home{
-            color: black;
+            color: var(--text);
             margin-top: 10px;
             text-decoration: none;
         }


### PR DESCRIPTION
## Summary

Fixes the visibility issue of the "← Back to Home" navigation link in the Audio Trimmer tool when dark mode is enabled.

## Changes

* Replaced the hardcoded `color: black` value in the `.back-home` style
* Updated the link color to use the theme variable `var(--text)`
* Ensures the navigation link adapts correctly to both light and dark themes

## Verification

* Verified the link is visible in light mode
* Verified the link remains visible in dark mode
* Confirmed the change affects only the Audio Trimmer tool

Fixes #190
