### PR TITLE
feat: add Open Graph metadata to tool pages

### DIFF
--- a/tools/api-client/api-client.html
+++ b/tools/api-client/api-client.html
@@ -5,6 +5,13 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>API Request Builder (Postman Lite) - Project Toolsuite</title>
     <meta name="description" content="Send HTTP requests, test REST API endpoints, inspect headers and JSON payloads directly from your browser.">
+    <meta property="og:title" content="API Client - Project Toolsuite" />
+    <meta property="og:description" content="Test and interact with APIs directly from your browser using a lightweight API client." />
+    <meta property="og:image" content="https://cdn-icons-png.flaticon.com/512/3522/3522262.png" />
+    <meta property="og:type" content="website" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="API Client - Project Toolsuite" />
+    <meta name="twitter:description" content="Test and interact with APIs directly from your browser using a lightweight API client." />
     <link rel="stylesheet" href="../../theme.css">
     <link rel="stylesheet" href="api-client.css">
     

--- a/tools/audio-trimmer/audio-trimmer.html
+++ b/tools/audio-trimmer/audio-trimmer.html
@@ -4,6 +4,13 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Audio Trimmer & Visualizer</title>
+    <meta property="og:title" content="Audio Trimmer - Project Toolsuite" />
+    <meta property="og:description" content="Trim audio files quickly and securely with a browser-based audio editing tool." />
+    <meta property="og:image" content="https://cdn-icons-png.flaticon.com/512/3522/3522262.png" />
+    <meta property="og:type" content="website" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Audio Trimmer - Project Toolsuite" />
+    <meta name="twitter:description" content="Trim audio files quickly and securely with a browser-based audio editing tool." />
     <link rel="stylesheet" href="../../theme.css">
     <script src="../../theme.js"></script>
     <link rel="stylesheet" href="../../assets/css/notifications.css">

--- a/tools/bezier-generator/bezier.html
+++ b/tools/bezier-generator/bezier.html
@@ -4,6 +4,13 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Cubic Bezier Generator</title>
+    <meta property="og:title" content="Cubic Bezier Generator - Project Toolsuite" />
+    <meta property="og:description" content="Design and visualize Bézier curves interactively for UI, graphics, and animation workflows." />
+    <meta property="og:image" content="https://cdn-icons-png.flaticon.com/512/3522/3522262.png" />
+    <meta property="og:type" content="website" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Cubic Bezier Generator - Project Toolsuite" />
+    <meta name="twitter:description" content="Design and visualize Bézier curves interactively for UI, graphics, and animation workflows." />
     <style>
 
         /* CSS Variables for raw brutalist theme matching */

--- a/tools/cicd-visualizer/cicd-visualizer.html
+++ b/tools/cicd-visualizer/cicd-visualizer.html
@@ -5,6 +5,13 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>CI/CD Visualizer - Project Toolsuite</title>
     <meta name="description" content="Offline CI/CD pipeline visualizer and builder. Drag, drop, and export your workflows.">
+    <meta property="og:title" content="CI/CD Visualizer - Project Toolsuite" />
+    <meta property="og:description" content="Visualize CI/CD workflows and pipelines using an interactive browser-based tool." />
+    <meta property="og:image" content="https://cdn-icons-png.flaticon.com/512/3522/3522262.png" />
+    <meta property="og:type" content="website" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="CI/CD Visualizer - Project Toolsuite" />
+    <meta name="twitter:description" content="Visualize CI/CD workflows and pipelines using an interactive browser-based tool." />
     <link rel="stylesheet" href="../../assets/css/notifications.css">
     <script src="../../assets/js/notifications.js" defer></script>
     <style>

--- a/tools/clip-path-generator/clip-path.html
+++ b/tools/clip-path-generator/clip-path.html
@@ -6,7 +6,13 @@
     <link rel="stylesheet" href="../../theme.css">
     <script src="../../theme.js"></script>
     <title>Visual CSS Clip-Path Generator</title>
-    
+    <meta property="og:title" content="CSS Clip Path Generator - Project Toolsuite" />
+    <meta property="og:description" content="Generate custom CSS clip-path shapes visually and copy the code instantly." />
+    <meta property="og:image" content="https://cdn-icons-png.flaticon.com/512/3522/3522262.png" />
+    <meta property="og:type" content="website" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="CSS Clip Path Generator - Project Toolsuite" />
+    <meta name="twitter:description" content="Generate custom CSS clip-path shapes visually and copy the code instantly." />
     <link rel="stylesheet" href="../../assets/css/notifications.css">
     <script src="../../assets/js/notifications.js" defer></script>
     <style>

--- a/tools/cron-explainer/cron.html
+++ b/tools/cron-explainer/cron.html
@@ -5,6 +5,13 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>CRON Schedule Explainer & Builder - Project Toolsuite</title>
     <meta name="description" content="Validate, explain, and build CRON expressions visually. View natural English translations and upcoming scheduled execution times.">
+    <meta property="og:title" content="Cron Expression Explainer - Project Toolsuite" />
+    <meta property="og:description" content="Understand and decode cron expressions with a simple browser-based cron explainer." />
+    <meta property="og:image" content="https://cdn-icons-png.flaticon.com/512/3522/3522262.png" />
+    <meta property="og:type" content="website" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Cron Expression Explainer - Project Toolsuite" />
+    <meta name="twitter:description" content="Understand and decode cron expressions with a simple browser-based cron explainer." />
     <link rel="stylesheet" href="../../theme.css">
     <link rel="stylesheet" href="cron.css">
     <script src="../../theme.js"></script>

--- a/tools/diff-checker/diff.html
+++ b/tools/diff-checker/diff.html
@@ -4,6 +4,31 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Visual Code Diff Checker</title>
+    <meta property="og:title" content="Visual Code Diff Checker - Project Toolsuite" />
+
+    <meta
+    property="og:description"
+    content="Compare text and code differences instantly with a fast browser-based visual diff checker."
+    />
+
+    <meta
+    property="og:image"
+    content="https://cdn-icons-png.flaticon.com/512/3522/3522262.png"
+    />
+
+    <meta property="og:type" content="website" />
+
+    <meta name="twitter:card" content="summary_large_image" />
+
+    <meta
+    name="twitter:title"
+    content="Visual Code Diff Checker - Project Toolsuite"
+    />
+
+    <meta
+    name="twitter:description"
+    content="Compare text and code differences instantly with a fast browser-based visual diff checker."
+    />
     <style>
 
         :root {

--- a/tools/email-validator/email-validator.html
+++ b/tools/email-validator/email-validator.html
@@ -5,6 +5,13 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Email Validator - Project Toolsuite</title>
     <meta name="description" content="Offline-first email address validator. Check syntax, typos, disposable domains, and role-based addresses.">
+    <meta property="og:title" content="Email Validator - Project Toolsuite" />
+    <meta property="og:description" content="Validate email addresses quickly and accurately using browser-based checks." />
+    <meta property="og:image" content="https://cdn-icons-png.flaticon.com/512/3522/3522262.png" />
+    <meta property="og:type" content="website" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Email Validator - Project Toolsuite" />
+    <meta name="twitter:description" content="Validate email addresses quickly and accurately using browser-based checks." />
     <link rel="stylesheet" href="../../assets/css/notifications.css">
     <script src="../../assets/js/notifications.js" defer></script>
     <style>

--- a/tools/github-actions-generator/github-actions-generator.html
+++ b/tools/github-actions-generator/github-actions-generator.html
@@ -5,6 +5,13 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>GitHub Actions Workflow Generator - Project Toolsuite</title>
     <meta name="description" content="Generate production-ready, customized GitHub Actions workflow files visually. Support for Node.js, Python, React, Docker, GitHub Pages, and Vercel.">
+    <meta property="og:title" content="GitHub Actions Generator - Project Toolsuite" />
+    <meta property="og:description" content="Generate GitHub Actions workflow configurations quickly using an interactive browser-based tool." />
+    <meta property="og:image" content="https://cdn-icons-png.flaticon.com/512/3522/3522262.png" />
+    <meta property="og:type" content="website" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="GitHub Actions Generator - Project Toolsuite" />
+    <meta name="twitter:description" content="Generate GitHub Actions workflow configurations quickly using an interactive browser-based tool." />
     <link rel="stylesheet" href="../../theme.css">
     <link rel="stylesheet" href="github-actions-generator.css">
     

--- a/tools/hex-inspector/hex.html
+++ b/tools/hex-inspector/hex.html
@@ -4,7 +4,13 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Hex Inspector - Large File Support</title>
-    
+    <meta property="og:title" content="Hex Inspector - Project Toolsuite" />
+    <meta property="og:description" content="Inspect hexadecimal data, analyze byte content, and explore file structures in your browser." />
+    <meta property="og:image" content="https://cdn-icons-png.flaticon.com/512/3522/3522262.png" />
+    <meta property="og:type" content="website" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Hex Inspector - Project Toolsuite" />
+    <meta name="twitter:description" content="Inspect hexadecimal data, analyze byte content, and explore file structures in your browser." />
     <link rel="stylesheet" href="../../assets/css/notifications.css">
     <script src="../../assets/js/notifications.js" defer></script>
     <style>

--- a/tools/ip-subnet-calculator/index.html
+++ b/tools/ip-subnet-calculator/index.html
@@ -5,6 +5,13 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>IP Subnet Calculator - Project Toolsuite</title>
     <meta name="description" content="Offline-first IPv4 subnet calculator. Calculate network ranges, broadcast addresses, usable hosts, binary masks, and subnet metadata.">
+    <meta property="og:title" content="IP Subnet Calculator - Project Toolsuite" />
+    <meta property="og:description" content="Calculate subnet masks, network ranges, and IP address information quickly and accurately." />
+    <meta property="og:image" content="https://cdn-icons-png.flaticon.com/512/3522/3522262.png" />
+    <meta property="og:type" content="website" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="IP Subnet Calculator - Project Toolsuite" />
+    <meta name="twitter:description" content="Calculate subnet masks, network ranges, and IP address information quickly and accurately." />
     <link rel="stylesheet" href="../../theme.css">
     <link rel="stylesheet" href="style.css">
     <script src="../../theme.js"></script>

--- a/tools/jwt-debugger/jwt-debugger.html
+++ b/tools/jwt-debugger/jwt-debugger.html
@@ -4,7 +4,13 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Secure JWT Debugger - Offline</title>
-
+    <meta property="og:title" content="JWT Debugger - Project Toolsuite" />
+    <meta property="og:description" content="Decode, inspect, and validate JSON Web Tokens securely in your browser." />
+    <meta property="og:image" content="https://cdn-icons-png.flaticon.com/512/3522/3522262.png" />
+    <meta property="og:type" content="website" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="JWT Debugger - Project Toolsuite" />
+    <meta name="twitter:description" content="Decode, inspect, and validate JSON Web Tokens securely in your browser." />
     <link rel="stylesheet" href="../../theme.css">
     <script src="../../theme.js"></script>
     <link rel="stylesheet" href="../../assets/css/notifications.css">

--- a/tools/linkedin-text-formatter/formatter.html
+++ b/tools/linkedin-text-formatter/formatter.html
@@ -4,7 +4,13 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>LinkedIn Text Formatter - Project Toolsuite</title>
-
+    <meta property="og:title" content="LinkedIn Text Formatter - Project Toolsuite" />
+    <meta property="og:description" content="Format LinkedIn posts with styled text to improve readability and engagement." />
+    <meta property="og:image" content="https://cdn-icons-png.flaticon.com/512/3522/3522262.png" />
+    <meta property="og:type" content="website" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="LinkedIn Text Formatter - Project Toolsuite" />
+    <meta name="twitter:description" content="Format LinkedIn posts with styled text to improve readability and engagement." />
     <link rel="stylesheet" href="../../theme.css" />
     <script src="../../theme.js"></script>
 

--- a/tools/logic-simulator/logic.html
+++ b/tools/logic-simulator/logic.html
@@ -4,6 +4,13 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Digital Logic Simulator</title>
+    <meta property="og:title" content="Digital Logic Simulator - Project Toolsuite" />
+    <meta property="og:description" content="Build and simulate digital logic circuits using an interactive browser-based logic simulator." />
+    <meta property="og:image" content="https://cdn-icons-png.flaticon.com/512/3522/3522262.png" />
+    <meta property="og:type" content="website" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Digital Logic Simulator - Project Toolsuite" />
+    <meta name="twitter:description" content="Build and simulate digital logic circuits using an interactive browser-based logic simulator." />
     <style>
 
         :root {

--- a/tools/nginx-generator/nginx-generator.html
+++ b/tools/nginx-generator/nginx-generator.html
@@ -5,6 +5,13 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>NGINX Configuration Generator - Project Toolsuite</title>
     <meta name="description" content="Generate production-ready NGINX configurations visually. Support for Reverse Proxy, SPA routing, SSL redirects, Gzip, Caching, and Rate Limiting.">
+    <meta property="og:title" content="NGINX Config Generator - Project Toolsuite" />
+    <meta property="og:description" content="Generate NGINX configuration files quickly with an interactive browser-based tool." />
+    <meta property="og:image" content="https://cdn-icons-png.flaticon.com/512/3522/3522262.png" />
+    <meta property="og:type" content="website" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="NGINX Config Generator - Project Toolsuite" />
+    <meta name="twitter:description" content="Generate NGINX configuration files quickly with an interactive browser-based tool." />
     <link rel="stylesheet" href="../../theme.css">
     <link rel="stylesheet" href="nginx-generator.css">
     

--- a/tools/regex-crossword/regex-crossword.html
+++ b/tools/regex-crossword/regex-crossword.html
@@ -4,6 +4,13 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Interactive Regex Crossword</title>
+    <meta property="og:title" content="Regex Crossword - Project Toolsuite" />
+    <meta property="og:description" content="Practice regular expressions through interactive crossword-style challenges." />
+    <meta property="og:image" content="https://cdn-icons-png.flaticon.com/512/3522/3522262.png" />
+    <meta property="og:type" content="website" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Regex Crossword - Project Toolsuite" />
+    <meta name="twitter:description" content="Practice regular expressions through interactive crossword-style challenges." />
     <style>
 
         :root {

--- a/tools/svg-optimizer/svg-optimizer.html
+++ b/tools/svg-optimizer/svg-optimizer.html
@@ -4,7 +4,13 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>SVG Optimizer & Sanitizer</title>
-    
+    <meta property="og:title" content="SVG Optimizer & Sanitizer - Project Toolsuite" />
+    <meta property="og:description" content="Optimize and sanitize SVG files to reduce size and improve performance directly in your browser." />
+    <meta property="og:image" content="https://cdn-icons-png.flaticon.com/512/3522/3522262.png" />
+    <meta property="og:type" content="website" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="SVG Optimizer & Sanitizer - Project Toolsuite" />
+    <meta name="twitter:description" content="Optimize and sanitize SVG files to reduce size and improve performance directly in your browser." />
     <link rel="stylesheet" href="../../assets/css/notifications.css">
     <script src="../../assets/js/notifications.js" defer></script>
     <style>

--- a/tools/synth-sequencer/synth.html
+++ b/tools/synth-sequencer/synth.html
@@ -4,6 +4,13 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Web Audio Synthesizer & Sequencer</title>
+    <meta property="og:title" content="Synth Sequencer - Project Toolsuite" />
+    <meta property="og:description" content="Create and experiment with audio sequences using an interactive browser-based synthesizer." />
+    <meta property="og:image" content="https://cdn-icons-png.flaticon.com/512/3522/3522262.png" />
+    <meta property="og:type" content="website" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Synth Sequencer - Project Toolsuite" />
+    <meta name="twitter:description" content="Create and experiment with audio sequences using an interactive browser-based synthesizer." />
     <link rel="stylesheet" href="../../theme.css">
     <script src="../../theme.js"></script>
     <style>

--- a/tools/text-to-speech/tts.html
+++ b/tools/text-to-speech/tts.html
@@ -5,7 +5,13 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Text to Speech - Project Toolsuite</title>
     <meta name="description" content="Listen to text using your browser's built-in speech synthesis.">
-
+    <meta property="og:title" content="Text to Speech - Project Toolsuite" />
+    <meta property="og:description" content="Convert text into natural-sounding speech directly in your browser." />
+    <meta property="og:image" content="https://cdn-icons-png.flaticon.com/512/3522/3522262.png" />
+    <meta property="og:type" content="website" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Text to Speech - Project Toolsuite" />
+    <meta name="twitter:description" content="Convert text into natural-sounding speech directly in your browser." />
     <link rel="stylesheet" href="../../theme.css">
     <script src="../../theme.js"></script>
     <style>

--- a/tools/unit-converter/unit-converter.html
+++ b/tools/unit-converter/unit-converter.html
@@ -5,6 +5,13 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Unit Converter - Project Toolsuite</title>
     <meta name="description" content="Convert between all common & tech units instantly. No server processing.">
+    <meta property="og:title" content="Unit Converter - Project Toolsuite" />
+    <meta property="og:description" content="Convert between different units quickly and accurately with a browser-based converter." />
+    <meta property="og:image" content="https://cdn-icons-png.flaticon.com/512/3522/3522262.png" />
+    <meta property="og:type" content="website" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Unit Converter - Project Toolsuite" />
+    <meta name="twitter:description" content="Convert between different units quickly and accurately with a browser-based converter." />
     <link rel="stylesheet" href="../../theme.css">
     <script src="../../theme.js"></script>
     


### PR DESCRIPTION
## Summary

Adds Open Graph and Twitter metadata to tool pages that were missing social sharing metadata.

## Changes Made

* Added `og:title` tags to affected tool pages
* Added `og:description` tags with tool-specific descriptions
* Added `og:image` and `og:type` metadata
* Added Twitter card metadata (`twitter:card`, `twitter:title`, and `twitter:description`)
* Maintained consistency with the existing metadata structure used across the project

## Benefits

* Improves social media link previews
* Enhances discoverability when tools are shared
* Provides better context to users before opening shared links
* Standardizes metadata across the repository

Closes #228
