### PR TITLE
feat: add recent tools sidebar with localStorage (#236)

### DIFF
--- a/index.html
+++ b/index.html
@@ -200,7 +200,7 @@
       }
       .workspace {
         display: grid;
-        grid-template-columns: 220px 1fr;
+        grid-template-columns: 220px 1fr 280px;
         gap: 40px;
       }
 
@@ -646,6 +646,58 @@
           border-width: 1px;
         }
       }
+      .recent-sidebar {
+  background: var(--surface);
+  border-radius: 12px;
+  padding: 1rem;
+  border: 2px solid var(--border);
+  height: fit-content;
+  position: sticky;
+  top: 20px;
+}
+.recent-sidebar h3 {
+  font-size: 1rem;
+  margin-top: 0;
+  margin-bottom: 0.8rem;
+  text-transform: uppercase;
+  border-bottom: 2px solid var(--border);
+  display: inline-block;
+  padding-right: 8px;
+}
+.recent-tools-ul {
+  list-style: none;
+  padding-left: 0;
+  margin: 0;
+}
+.recent-tools-ul li {
+  margin-bottom: 0.6rem;
+}
+.recent-tools-ul a {
+  color: var(--text);
+  text-decoration: none;
+  font-size: 0.9rem;
+  display: block;
+  padding: 4px 0;
+  transition: 0.2s;
+  border-bottom: 1px dotted var(--border);
+}
+.recent-tools-ul a:hover {
+  color: #7c3aed;
+  transform: translateX(4px);
+}
+.recent-placeholder {
+  color: var(--muted);
+  font-style: italic;
+  font-size: 0.85rem;
+  margin: 0;
+}
+/* mobile pe recent sidebar stack ho */
+@media (max-width: 850px) {
+  .recent-sidebar {
+    position: static;
+    margin-top: 20px;
+  }
+}
     </style>
     <script
       defer
@@ -773,6 +825,13 @@
             <!-- Tools will be injected here -->
           </div>
         </main>
+
+        <aside class="recent-sidebar" id="recentSidebar">
+          <h3>📌 Recent Tools</h3>
+          <div id="recent-tools-list">
+            <p class="recent-placeholder">No recent tools yet</p>
+        </div>
+        </aside>
       </div>
 
       <footer>

--- a/index.html
+++ b/index.html
@@ -681,19 +681,19 @@
   transition: 0.2s;
   border-bottom: 1px dotted var(--border);
 }
-.recent-tools-ul a:hover {
+.-tools-ul a:hover {
   color: #7c3aed;
   transform: translateX(4px);
 }
-.recent-placeholder {
+.-placeholder {
   color: var(--muted);
   font-style: italic;
   font-size: 0.85rem;
   margin: 0;
 }
-/* mobile pe recent sidebar stack ho */
+/* mobile pe  sidebar stack ho */
 @media (max-width: 850px) {
-  .recent-sidebar {
+  .-sidebar {
     position: static;
     margin-top: 20px;
   }
@@ -826,8 +826,8 @@
           </div>
         </main>
 
-        <aside class="recent-sidebar" id="recentSidebar">
-          <h3>📌 Recent Tools</h3>
+        <aside class="-sidebar" id="Sidebar">
+          <h3>Recent Tools</h3>
           <div id="recent-tools-list">
             <p class="recent-placeholder">No recent tools yet</p>
         </div>

--- a/theme.css
+++ b/theme.css
@@ -120,3 +120,58 @@ footer a:focus-visible {
   outline: 3px solid var(--text);
   outline-offset: 3px;
 }
+
+/* Recent Tools Sidebar */
+.recent-sidebar {
+  background: var(--surface);
+  border-radius: 12px;
+  padding: 1rem;
+  border: 2px solid var(--border);
+  height: fit-content;
+  position: sticky;
+  top: 20px;
+}
+.recent-sidebar h3 {
+  font-size: 1rem;
+  margin-top: 0;
+  margin-bottom: 0.8rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  border-bottom: 2px solid var(--border);
+  display: inline-block;
+  padding-right: 8px;
+}
+.recent-tools-ul {
+  list-style: none;
+  padding-left: 0;
+  margin: 0;
+}
+.recent-tools-ul li {
+  margin-bottom: 0.6rem;
+}
+.recent-tools-ul a {
+  color: var(--text);
+  text-decoration: none;
+  font-size: 0.9rem;
+  display: block;
+  padding: 4px 0;
+  transition: 0.2s;
+  border-bottom: 1px dotted var(--border);
+}
+.recent-tools-ul a:hover {
+  color: #7c3aed;
+  transform: translateX(4px);
+}
+.recent-placeholder {
+  color: var(--muted);
+  font-style: italic;
+  font-size: 0.85rem;
+  margin: 0;
+}
+/* Responsive: on mobile recent sidebar will stack normally */
+@media (max-width: 850px) {
+  .recent-sidebar {
+    position: static;
+    margin-top: 20px;
+  }
+}

--- a/theme.js
+++ b/theme.js
@@ -94,3 +94,64 @@ window.addEventListener('storage', (e) => {
         applyTheme(e.newValue || getSystemTheme());
     }
 });
+
+// ---------- Recent Tools with localStorage ----------
+const RECENT_TOOLS_KEY = "recentTools";
+const MAX_RECENT = 5;
+
+function saveRecentTool(toolName, toolUrl) {
+  let recent = JSON.parse(localStorage.getItem(RECENT_TOOLS_KEY)) || [];
+  recent = recent.filter(item => item.name !== toolName && item.url !== toolUrl);
+  recent.unshift({ name: toolName, url: toolUrl });
+  if (recent.length > MAX_RECENT) recent = recent.slice(0, MAX_RECENT);
+  localStorage.setItem(RECENT_TOOLS_KEY, JSON.stringify(recent));
+  renderRecentTools();
+}
+
+function renderRecentTools() {
+  const container = document.getElementById("recent-tools-list");
+  if (!container) return;
+  const recent = JSON.parse(localStorage.getItem(RECENT_TOOLS_KEY)) || [];
+  if (recent.length === 0) {
+    container.innerHTML = '<p class="recent-placeholder">No recent tools yet</p>';
+    return;
+  }
+  const html = '<ul class="recent-tools-ul">' +
+    recent.map(item => `<li><a href="${escapeHtml(item.url)}">${escapeHtml(item.name)}</a></li>`).join('') +
+    '</ul>';
+  container.innerHTML = html;
+}
+
+function escapeHtml(str) {
+  return str.replace(/[&<>]/g, function(m) {
+    if (m === '&') return '&amp;';
+    if (m === '<') return '&lt;';
+    if (m === '>') return '&gt;';
+    return m;
+  });
+}
+
+function attachRecentToolsClickHandler() {
+  document.addEventListener('click', (e) => {
+    const toolLink = e.target.closest('.tool-link, .tool-card a, a[href*="tools/"]');
+    if (!toolLink) return;
+    if (toolLink.closest('.tag-list, .recent-sidebar, .footer-links')) return;
+    const toolName = toolLink.innerText.trim() || toolLink.getAttribute('data-tool-name') || "Tool";
+    let toolUrl = toolLink.getAttribute('href');
+    if (toolUrl && !toolUrl.startsWith('#') && !toolUrl.startsWith('javascript:')) {
+      saveRecentTool(toolName, toolUrl);
+    }
+  });
+}
+
+// existing DOMContentLoaded listener ke andar yeh do lines add karo
+// agar DOMContentLoaded already hai toh uske andar add karo, nahi toh naya listener banao
+if (document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', () => {
+    renderRecentTools();
+    attachRecentToolsClickHandler();
+  });
+} else {
+  renderRecentTools();
+  attachRecentToolsClickHandler();
+}


### PR DESCRIPTION
## Closes #236

Adds a "Recent Tools" section in the right sidebar that stores the last 5 visited tools using localStorage. Clicking on any tool card records the tool name and URL. On homepage reload, the list persists.

**Changes:**
- `index.html`: added recent sidebar HTML, updated grid to 3 columns, added CSS styles
- `theme.js`: added `saveRecentTool()`, `renderRecentTools()`, click handler for tool links
- `theme.css`: added styles for recent sidebar and responsiveness

**Testing:**
- ✅ Click tool → appears in recent list
- ✅ Duplicate click moves to top
- ✅ Refresh page → list persists
- ✅ No recent tools → shows placeholder message