### PR TITLE
Add Light/Dark Theme Toggle to Missing Pages -

### DIFF
--- a/tools/archive-studio/archive_studio.html
+++ b/tools/archive-studio/archive_studio.html
@@ -328,8 +328,13 @@
 <body>
 
     <div class="app-container">
+        
         <aside class="sidebar">
             <div class="brand">ARCHIVE<span>_STUDIO</span></div>
+            <button class="dark-mode-toggle" onclick="toggleTheme()" id="themeBtn">
+                DARK MODE
+            </button>
+            
             <div class="nav-group">
                 <button class="nav-item active" onclick="app.switchModule('extractor')">
                     <span>📂</span> EXTRACTOR

--- a/tools/audio-trimmer/audio-trimmer.html
+++ b/tools/audio-trimmer/audio-trimmer.html
@@ -41,11 +41,25 @@
         .container {
             max-width: 900px;
             width: 100%;
-            background-color: var(--card-bg);
-            padding: 20px;
-            border-radius: 12px;
-            box-shadow: 0 4px 6px rgba(0,0,0,0.3);
-            border: 1px solid var(--border);
+
+            background: var(--bg);
+            border: 2px solid var(--border);
+
+            padding: 24px;
+        }
+
+        .upload-area {
+            border: 2px dashed var(--border);
+            padding: 40px 20px;
+
+            background: var(--bg);
+
+            transition: all 0.2s ease;
+        }
+
+        .upload-area:hover {
+            background: var(--tag-bg);
+            transform: translateY(-2px);
         }
 
         h1 {
@@ -212,7 +226,21 @@
         }
         a:hover{
             text-decoration: underline dotted black;
-}
+        }
+
+        footer {
+            margin-top: 20px;
+        }
+
+        footer a {
+            color: var(--text);
+            text-decoration: none;
+            border-bottom: 1px dotted var(--border);
+        }
+
+        footer a:hover {
+            opacity: 0.8;
+        }
 
     
     </style>
@@ -221,6 +249,11 @@
 
     <div class="container">
         <h1>Audio Trimmer</h1>
+        <button class="dark-mode-toggle"
+            onclick="toggleTheme()"
+            id="themeBtn">
+            DARK MODE
+        </button>
         <p class="desc">Trim audio files securely in your browser. No server uploads.</p>
 
         <div class="upload-area" id="drop-zone" onclick="document.getElementById('file-input').click()">

--- a/tools/bezier-generator/bezier.html
+++ b/tools/bezier-generator/bezier.html
@@ -15,11 +15,11 @@
 
         /* CSS Variables for raw brutalist theme matching */
         :root {
-            --bg-color: #FFFFFF;
+            --bg-color: var(--bg);
             --text-color: var(--text);
-            --border-thick: 2px solid #000000;
-            --border-heavy: 5px solid #000000;
-            --border-dashed: 1px dashed #000000;
+            --border-thick: 2px solid var(--border);
+            --border-heavy: 5px solid var(--border);
+            --border-dashed: 1px dashed var(--border);
         }
 
         /* Basic Layout Resets */
@@ -43,6 +43,25 @@
             margin: 40px auto;
         }
 
+
+        .dark-mode-toggle {
+            margin-top: 12px;
+            padding: 8px 12px;
+            border: var(--border-thick);
+            background: var(--bg);
+            color: var(--text);
+            font-family: inherit;
+            font-size: 0.8rem;
+            font-weight: bold;
+            text-transform: uppercase;
+            cursor: pointer;
+            width: auto;
+        }
+
+        .dark-mode-toggle:hover {
+            background: var(--text);
+            color: var(--bg);
+        }
         /* Heavy Anchor Header Underline styling */
         header {
             margin-bottom: 40px;

--- a/tools/clip-path-generator/clip-path.html
+++ b/tools/clip-path-generator/clip-path.html
@@ -27,38 +27,55 @@
 
         body {
             font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
-            background-color: var(--bg-color);
-            color: var(--text-color);
             margin: 0;
             display: flex;
             height: 100vh;
             overflow: hidden;
+            background: var(--bg);
+            color: var(--text);
         }
 
         /* Sidebar Controls */
         .sidebar {
-            width: 300px;
-            background-color: var(--panel-bg);
+            width: 320px;
+            background: var(--bg);
+            border-right: 2px solid var(--border);
             padding: 20px;
             display: flex;
             flex-direction: column;
             gap: 20px;
-            border-right: 1px solid #444;
-            box-shadow: 2px 0 5px rgba(0,0,0,0.3);
+            box-shadow: 4px 0 20px rgba(0,0,0,0.08);
             z-index: 10;
         }
 
         h2 { margin-top: 0; font-size: 1.2rem; }
 
+        .dark-mode-toggle {
+            margin-top: 12px;
+            padding: 8px 12px;
+            border: 2px solid var(--border);
+            background: var(--bg);
+            color: var(--text);
+            cursor: pointer;
+            font-family: inherit;
+            font-size: 0.8rem;
+            text-transform: uppercase;
+        }
+
+        .dark-mode-toggle:hover {
+            background: var(--text);
+            color: var(--bg);
+        }
+
         .code-box {
-            background: #111;
             padding: 15px;
             border-radius: 6px;
             font-family: monospace;
-            color: #9cdcfe;
-            border: 1px solid #444;
             word-break: break-all;
             position: relative;
+            background: var(--bg);
+            border: 2px solid var(--border);
+            color: #007acc;
         }
 
         .presets {
@@ -68,16 +85,24 @@
         }
 
         button {
-            padding: 8px;
-            background-color: #444;
-            color: white;
-            border: none;
-            border-radius: 4px;
-            cursor: pointer;
-            transition: 0.2s;
+            padding: 10px;
+            border-radius: 10px;
+            border: 2px solid var(--border);
+            background: var(--bg);
+            color: var(--text);
+            transition: all 0.25s ease;
         }
-        button:hover { background-color: var(--accent-color); }
-        button.active { background-color: var(--accent-color); }
+
+        button:hover {
+            transform: translateY(-2px);
+            background: var(--accent-color);
+            color: white;
+        }
+
+        button.active {
+            background: var(--accent-color);
+            color: white;
+        }
 
         .copy-btn {
             margin-top: 10px;
@@ -124,19 +149,35 @@
 
         /* Custom Image Upload */
         .upload-section {
-            border-top: 1px solid #444;
+            border-top: 2px solid var(--border);
             padding-top: 15px;
         }
         input[type="file"] { font-size: 0.8rem; }
 
-    
+        .footer-link {
+            position: fixed;
+            bottom: 20px;
+            left: 20px;
+            z-index: 100;
+        }
+
+        .footer-link a {
+            color: var(--text);
+            text-decoration: none;
+            border-bottom: 1px dotted var(--border);
+            padding: 8px;
+        }
+            
     </style>
 </head>
 <body>
 
     <div class="sidebar">
         <h2>Clip-Path Generator</h2>
-        
+
+        <button class="dark-mode-toggle" onclick="toggleTheme()" id="themeBtn">
+            DARK MODE
+        </button>
         <div>
             <label>Presets:</label>
             <div class="presets">
@@ -168,8 +209,8 @@
         <div class="demo-box" id="target-element">
             </div>
     </div>
-    <footer>
-        <a href="../../index.html">&larr; Back to Home</a>
+    <footer class="footer-link">
+        <a href="../../index.html">← Back to Home</a>
     </footer>
     <script src="clip-logic.js"></script>
 </body>

--- a/tools/git-studio/git_studio.html
+++ b/tools/git-studio/git_studio.html
@@ -25,64 +25,81 @@
 
         /* Base Reset */
         * { margin: 0; padding: 0; box-sizing: border-box; }
-        body { font-family: 'Courier New', monospace; background: #000; color: #fff; overflow: hidden; }
+        body {
+            font-family: 'Courier New', monospace;
+            background: var(--bg);
+            color: var(--text);
+            overflow: hidden;
+        }
 
         /* Layout */
         .container { display: flex; height: 100vh; }
         
         /* Sidebar */
         .sidebar { width: 280px; background: var(--tag-bg); border-right: 4px solid var(--border); display: flex; flex-direction: column; flex-shrink: 0; }
-        .sidebar-header { background: #000; color: #fff; padding: 20px; border-bottom: 4px solid var(--border); }
+        .sidebar-header { background: var(--tag-bg);color: var(--text); padding: 20px; border-bottom: 4px solid var(--border); }
         .sidebar-header h1 { font-size: 24px; font-weight: bold; letter-spacing: 2px; }
         .tool-list { list-style: none; overflow-y: auto; flex: 1; }
         .tool-item { padding: 16px 20px; border-bottom: 3px solid var(--border); cursor: pointer; background: var(--tag-bg); color: var(--text); font-weight: bold; transition: 0.1s; display: flex; align-items: center; }
         .tool-item:hover { background: var(--bg); padding-left: 24px; }
-        .tool-item.active { background: #000; color: #fff; }
+        .tool-item.active {background: #000;color: #fff;}
         .tool-item.active::before { content: '►'; margin-right: 10px; }
 
         /* Main Content */
         .main-content { flex: 1; display: flex; flex-direction: column; overflow: hidden; }
-        .header { background: #000; border-bottom: 4px solid #fff; padding: 20px 30px; display: flex; justify-content: space-between; align-items: center; }
-        .btn { background: var(--bg); color: var(--text); border: 3px solid var(--border); padding: 10px 20px; font-family: inherit; font-weight: bold; cursor: pointer; box-shadow: 4px 4px 0 var(--border); transition: 0.1s; }
+        .header { background: var(--tag-bg);border-bottom: 4px solid var(--border); padding: 20px 30px; display: flex; justify-content: space-between; align-items: center; }
+        .btn { background: var(--bg); color: var(--text); border: 3px solid var(--border); padding: 10px 20px; font-family: inherit; font-weight: bold; cursor: pointer; box-shadow: 4px 4px 0 var(--border); transition: 0.1s; margin-right: 150px;}
         .btn:active { transform: translate(4px, 4px); box-shadow: none; }
 
         /* Workspace & Views */
-        .workspace { flex: 1; display: flex; overflow: hidden; background: #1a1a1a; position: relative; }
+        .workspace { flex: 1; display: flex; overflow: hidden; background: var(--bg); position: relative; }
         .main-area { flex: 1; position: relative; overflow: hidden; display: flex; flex-direction: column; }
         
         /* Persistent View Containers */
-        .view-section { width: 100%; height: 100%; display: none; overflow: auto; position: absolute; top: 0; left: 0; background: #1a1a1a; }
+        .view-section { width: 100%; height: 100%; display: none; overflow: auto; position: absolute; top: 0; left: 0;  background: var(--bg); }
         .view-section.active { display: block; }
 
         /* Graph View Specifics */
-        #graph-view { overflow: hidden; } /* Canvas needs no scroll */
-        .upload-zone { position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%); border: 4px dashed #fff; padding: 60px; text-align: center; cursor: pointer; z-index: 10; background: rgba(0,0,0,0.8); }
-        .upload-zone:hover { border-color: #00ff00; background: #000; }
-        canvas { display: block; background: #1a1a1a; cursor: grab; }
+        #graph-view { overflow: hidden;  } /* Canvas needs no scroll */
+        .upload-zone {
+            position: absolute;
+            top: 50%;
+            left: 50%;
+            transform: translate(-50%, -50%);
+            border: 4px dashed var(--border);
+            background: var(--tag-bg);
+            color: var(--text);
+            padding: 60px;
+            text-align: center;
+            cursor: pointer;
+            z-index: 10;
+        }
+        .upload-zone:hover { border-color: #00ff00; background: var(--bg); }
+        canvas { display: block;  background: var(--bg); cursor: grab; }
         canvas:active { cursor: grabbing; }
 
         /* UI Overlays */
         .controls { position: absolute; top: 20px; right: 20px; display: flex; gap: 10px; z-index: 20; }
-        .control-btn { width: 40px; height: 40px; border: 3px solid #fff; background: #000; color: #fff; font-size: 20px; cursor: pointer; display: flex; align-items: center; justify-content: center; }
+        .control-btn { width: 40px; height: 40px; border: 3px solid var(--border); background: var(--bg);color: var(--text); font-size: 20px; cursor: pointer; display: flex; align-items: center; justify-content: center; }
         .control-btn:hover { background: var(--bg); color: var(--text); }
         
-        .legend { position: absolute; bottom: 20px; left: 20px; background: #000; border: 3px solid #fff; padding: 15px; font-size: 12px; z-index: 20; }
+        .legend { position: absolute; bottom: 20px; left: 20px; background: var(--tag-bg); border: 3px solid var(--border); padding: 15px; font-size: 12px; z-index: 20; }
         .legend-item { display: flex; align-items: center; gap: 10px; margin-bottom: 5px; }
-        .legend-color { width: 15px; height: 15px; border: 1px solid #fff; }
+        .legend-color { width: 15px; height: 15px; border: 1px solid var(--border); }
 
         /* Info Panel */
         .info-panel { width: 350px; background: var(--tag-bg); border-left: 4px solid var(--border); overflow-y: auto; color: var(--text); display: flex; flex-direction: column; }
-        .panel-header { background: #000; color: #fff; padding: 15px; font-weight: bold; border-bottom: 4px solid var(--border); }
+        .panel-header { background: var(--tag-bg);color: var(--text); padding: 15px; font-weight: bold; border-bottom: 4px solid var(--border); }
         .panel-content { padding: 20px; }
         .commit-info-item { margin-bottom: 15px; }
         .commit-info-label { font-size: 11px; font-weight: bold; margin-bottom: 4px; color: #555; }
         .commit-info-value { border: 2px solid var(--border); padding: 8px; background: var(--bg); font-size: 13px; word-break: break-all; }
 
         /* Lists (Branches, Files, History) */
-        .list-container { padding: 40px; color: #fff; max-width: 1000px; margin: 0 auto; }
+        .list-container { padding: 40px; color: var(--text); max-width: 1000px; margin: 0 auto; }
         .list-item { background: var(--bg); color: var(--text); padding: 12px; border: 3px solid var(--border); margin-bottom: 10px; cursor: pointer; display: flex; justify-content: space-between; align-items: center; font-weight: bold; }
-        .list-item:hover { background: #000; color: #fff; }
-        .list-item.current { background: #000; color: #fff; border-color: #00ff00; }
+        .list-item:hover {  background: var(--tag-bg);color: var(--text);}
+        .list-item.current { background: var(--tag-bg);color: var(--text);border-color: var(--border);}
         
         /* Stats Grid */
         .stats-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(200px, 1fr)); gap: 20px; padding: 40px; }
@@ -90,17 +107,54 @@
         .stat-value { font-size: 36px; font-weight: bold; }
 
         /* Diff View */
-        .diff-view-content { padding: 20px; color: #fff; }
+        .diff-view-content { padding: 20px; color: var(--text); }
         .diff-file { border: 2px solid #fff; margin-bottom: 20px; background: #111; }
         .diff-header { background: var(--bg); color: var(--text); padding: 10px; font-weight: bold; }
         .diff-lines { padding: 10px; font-size: 12px; line-height: 1.4; }
         .diff-add { color: #00ff00; background: rgba(0, 255, 0, 0.1); display: block; }
         .diff-remove { color: #ff0000; background: rgba(255, 0, 0, 0.1); display: block; }
         .diff-context { color: var(--muted); display: block; }
+        .dark-mode-toggle {
+            padding: 10px 16px;
+            border: 3px solid var(--border);
+            background: var(--bg);
+            color: var(--text);
+            cursor: pointer;
+            font-family: inherit;
+            font-weight: bold;
+            text-transform: uppercase;
+            transition: 0.2s;
+        }
 
+        .dark-mode-toggle:hover {
+            background: var(--text);
+            color: var(--bg);
+        }
         /* Footer */
-        .footer { background: #000; border-top: 4px solid #fff; padding: 10px 30px; color: #fff; font-size: 12px; }
+        .footer {  background: var(--tag-bg);border-top: 4px solid var(--border);color: var(--text);padding: 10px 30px;  font-size: 12px; }
         .tooltip { position: absolute; background: #000; color: #fff; border: 2px solid #fff; padding: 5px 10px; font-size: 12px; pointer-events: none; display: none; z-index: 1000; }
+
+        .tool-footer {
+            padding: 12px 30px;
+            background: var(--tag-bg);
+            border-top: 2px solid var(--border);
+        }
+
+        .back-home-btn {
+            display: inline-block;
+            padding: 8px 16px;
+            border: 2px solid var(--border);
+            background: var(--bg);
+            color: var(--text);
+            text-decoration: none;
+            font-weight: bold;
+            transition: 0.2s;
+        }
+
+        .back-home-btn:hover {
+            background: var(--text);
+            color: var(--bg);
+        }
     
     </style>
     
@@ -124,8 +178,17 @@
             <div class="header">
                 <h2 id="tool-title">COMMIT GRAPH</h2>
                 <div>
-                    <button class="btn" onclick="document.getElementById('folder-input').click()">LOAD REPO</button>
-                    <input type="file" id="folder-input" webkitdirectory directory multiple style="display: none;">
+                    <div style="display:flex; gap:10px; align-items:center;">
+                        <button class="dark-mode-toggle" onclick="toggleTheme()" id="themeBtn">
+                            DARK MODE
+                        </button>
+
+                        <button class="btn" onclick="document.getElementById('folder-input').click()">
+                            LOAD REPO
+                        </button>
+
+                        <input type="file" id="folder-input" webkitdirectory directory multiple style="display: none;">
+                    </div>
                 </div>
             </div>
 
@@ -134,8 +197,8 @@
                     
                     <div id="graph-view" class="view-section active">
                         <div id="upload-zone" class="upload-zone">
-                            <div>DROP PROJECT FOLDER HERE</div>
-                            <div style="font-size:12px; margin-top:10px; color:#aaa;">(Must contain .git)</div>
+                            <div style = "color: var(--muted);">DROP PROJECT FOLDER HERE</div>
+                            <div style="font-size:12px; margin-top:10px; color: var(--muted);">(Must contain .git)</div>
                         </div>
                         <canvas id="commit-graph"></canvas>
                         
@@ -168,7 +231,10 @@
                     </div>
 
                     <div id="stats-view" class="view-section">
-                        <div class="stats-grid" id="stats-grid"></div>
+                        <div class="stats-grid">
+                            <h2>STATISTICS</h2>
+                            <div id="stats-grid"></div>
+                        </div>
                     </div>
 
                     <div id="history-view" class="view-section">
@@ -199,9 +265,10 @@
             <div class="footer">
                 <span id="status-bar">READY</span>
             </div>
-
-            <footer>
-                <a href="../../index.html">&larr; Back to Home</a>
+            <footer class="tool-footer">
+                <a href="../../index.html" class="back-home-btn">
+                    ← Back to Home
+                </a>
             </footer>
         </div>
     </div>

--- a/tools/git-studio/studio_git.js
+++ b/tools/git-studio/studio_git.js
@@ -447,5 +447,26 @@ window.app = {
     }
 };
 
+function updateThemeButton() {
+    const btn = document.getElementById("themeBtn");
+    if (!btn) return;
+
+    btn.textContent =
+        document.documentElement.getAttribute("data-theme") === "dark"
+            ? "LIGHT MODE"
+            : "DARK MODE";
+}
+
+document.addEventListener("DOMContentLoaded", () => {
+    updateThemeButton();
+
+    const observer = new MutationObserver(updateThemeButton);
+
+    observer.observe(document.documentElement, {
+        attributes: true,
+        attributeFilter: ["data-theme"]
+    });
+});
+
 // Start
 window.onload = () => window.app.init();

--- a/tools/glass studio/glass-studio.html
+++ b/tools/glass studio/glass-studio.html
@@ -55,6 +55,23 @@ h1 {
     margin: 0; 
 }
 
+.dark-mode-toggle {
+    margin-top: 12px;
+    padding: 8px 12px;
+    border: 2px solid var(--border);
+    background: var(--bg);
+    color: var(--text);
+    cursor: pointer;
+    font-family: inherit;
+    font-size: 0.8rem;
+    text-transform: uppercase;
+}
+
+.dark-mode-toggle:hover {
+    background: var(--text);
+    color: var(--bg);
+}
+
 /* SCROLL AREA */
 .scroll-area { 
     padding: 24px; 
@@ -147,9 +164,9 @@ input[type="color"]:focus-visible {
     position: absolute; 
     top: 8px; 
     right: 8px; 
-    background: #000; 
-    border: none; 
-    color: #fff; 
+    background: var(--text);
+    color: var(--bg);
+    border: none;
     font-size: 0.6rem; 
     padding: 5px 10px; 
     cursor: pointer; 
@@ -157,7 +174,8 @@ input[type="color"]:focus-visible {
 }
 
 .copy-btn:hover { 
-    background: #333; 
+    /* background: #333;  */
+    opacity: 0.85;
 }
 
 /* CANVAS */
@@ -252,6 +270,9 @@ input[type="color"]:focus-visible {
 <div class="sidebar">
     <div class="sidebar-header">
         <h1>Glass Studio</h1>
+        <button class="dark-mode-toggle" onclick="toggleTheme()" id="themeBtn">
+            DARK MODE
+        </button>
     </div>
     <div class="scroll-area">
         <div class="control-group">
@@ -291,9 +312,10 @@ input[type="color"]:focus-visible {
             <div id="codeOutput">/* CSS will appear here */</div>
         </div>
 
-        <div style="margin-top: 34px;">
-            <a href="../../index.html" style="color:#000; text-decoration:none; border-bottom:1px dotted #000; font-size:0.8rem;">← BACK TO HOME</a>
-        </div>
+        <a href="../../index.html"
+                style="color:var(--text); text-decoration:none; border-bottom:1px dotted var(--border); font-size:0.8rem;">
+            ← BACK TO HOME
+        </a>
     </div>
 </div>
 

--- a/tools/hex-inspector/hex.html
+++ b/tools/hex-inspector/hex.html
@@ -28,8 +28,8 @@
 
         body {
             font-family: 'Consolas', 'Monaco', monospace;
-            background-color: var(--bg-color);
-            color: var(--text-color);
+            background: var(--bg);
+            color: var(--text);
             margin: 0;
             padding: 20px;
             display: flex;
@@ -43,12 +43,35 @@
         .toolbar {
             display: flex;
             gap: 15px;
-            margin-bottom: 15px;
             align-items: center;
             flex-wrap: wrap;
-            background: var(--panel-bg);
-            padding: 10px;
-            border-radius: 6px;
+
+            background: var(--bg);
+            border: 2px solid var(--border);
+            padding: 12px;
+            margin-bottom: 15px;
+        }
+
+        .toolbar,
+        .hex-container {
+            background: var(--bg);
+            border-color: var(--border);
+        }
+
+        .dark-mode-toggle {
+            padding: 8px 12px;
+            border: 2px solid var(--border);
+            background: var(--bg);
+            color: var(--text);
+            cursor: pointer;
+            font-family: inherit;
+            font-size: 0.8rem;
+            text-transform: uppercase;
+        }
+
+        .dark-mode-toggle:hover {
+            background: var(--text);
+            color: var(--bg);
         }
 
         button {
@@ -64,26 +87,28 @@
         button:disabled { background-color: #444; cursor: not-allowed; }
 
         input[type="number"], input[type="text"] {
-            background: #3c3c3c;
-            border: 1px solid #555;
-            color: white;
-            padding: 5px;
-            border-radius: 4px;
+            background: var(--bg);
+            border: 2px solid var(--border);
+            color: var(--text);
+            padding: 8px;
             font-family: inherit;
         }
 
         /* Hex View Container */
         .hex-container {
             flex-grow: 1;
-            background-color: var(--panel-bg);
-            border: 1px solid #333;
+
+            background: var(--bg);
+            border: 2px solid var(--border);
+
             overflow-y: auto;
             display: grid;
-            grid-template-columns: 80px 1fr 180px; /* Offset | Hex | ASCII */
+            grid-template-columns: 90px 1fr 220px;
             gap: 15px;
-            padding: 10px;
+            padding: 15px;
+
             font-size: 14px;
-            line-height: 20px;
+            line-height: 22px;
         }
 
         .col-offset { color: var(--offset-color); text-align: right; user-select: none; }
@@ -93,17 +118,30 @@
         /* Navigation Footer */
         .status-bar {
             margin-top: 15px;
+            padding-top: 10px;
+            border-top: 2px solid var(--border);
+
             display: flex;
             justify-content: space-between;
             align-items: center;
-            font-size: 0.9rem;
-            color: #aaa;
+
+            color: var(--text);
         }
 
         .nav-controls {
             display: flex;
             gap: 5px;
             align-items: center;
+        }
+
+        footer a {
+            color: var(--text);
+            text-decoration: none;
+            border-bottom: 1px dotted var(--border);
+        }
+
+        footer a:hover {
+            opacity: 0.8;
         }
         
         /* Utility */
@@ -129,6 +167,9 @@
         </div>
 
         <div style="flex-grow: 1;"></div>
+        <button class="dark-mode-toggle" onclick="toggleTheme()" id="themeBtn">
+            DARK MODE
+        </button>
         <span id="file-name">No file loaded</span>
         <span id="file-size"></span>
     </div>

--- a/tools/logic-simulator/logic.html
+++ b/tools/logic-simulator/logic.html
@@ -26,8 +26,8 @@
 
         body {
             font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
-            background-color: var(--bg-color);
-            color: var(--text-color);
+            background-color: var(--bg);
+            color: var(--text);
             margin: 0;
             display: flex;
             height: 100vh;
@@ -35,15 +35,33 @@
             user-select: none;
         }
 
+        .dark-mode-toggle {
+            margin-bottom: 16px;
+            padding: 8px 12px;
+            border: 2px solid var(--border);
+            background: var(--bg);
+            color: var(--text);
+            cursor: pointer;
+            font-family: inherit;
+            font-size: 0.75rem;
+            text-transform: uppercase;
+            display: inline-block;
+            width: fit-content;
+        }
+
+        .dark-mode-toggle:hover {
+            opacity: 0.85;
+        }
+
         /* Sidebar container */
         .sidebar {
             width: 260px;
-            background-color: var(--panel-bg);
-            border-right: 1px solid #27272a;
+            background-color: var(--bg);
+            border-right: 1px solid var(--border);
             display: flex;
             flex-direction: column;
             padding: 20px;
-            z-index: 100;
+            z-index: 200;
             box-shadow: 2px 0 10px rgba(0,0,0,0.5);
         }
 
@@ -53,7 +71,7 @@
             font-weight: 700;
             letter-spacing: -0.025em;
         }
-        p.desc { font-size: 0.8rem; color: #a1a1aa; margin-bottom: 20px; line-height: 1.4; }
+        p.desc { font-size: 0.8rem;  color: var(--muted); margin-bottom: 20px; line-height: 1.4; }
 
         .component-list {
             display: grid;
@@ -63,9 +81,9 @@
         }
 
         button.comp-btn {
-            background: var(--gate-bg);
-            border: 1px solid var(--gate-border);
-            color: #e4e4e7;
+            background: var(--bg);
+            border: 1px solid var(--border);
+            color: var(--text);
             padding: 8px;
             border-radius: 6px;
             cursor: pointer;
@@ -75,8 +93,8 @@
         }
         button.comp-btn:hover { 
             border-color: var(--accent-color); 
-            background: #27272a; 
-            color: #fff;
+            background: var(--tag-bg);
+            color: var(--text);
         }
 
         .truth-table-panel {
@@ -88,7 +106,7 @@
         
         .truth-table-panel h3 {
             font-size: 0.85rem;
-            color: #e4e4e7;
+            color: var(--text);
             margin-top: 0;
             margin-bottom: 10px;
         }
@@ -99,25 +117,25 @@
             font-size: 0.75rem;
             text-align: center;
         }
-        th, td { border: 1px solid #27272a; padding: 6px; }
-        th { background: #202024; color: var(--accent-color); font-weight: 600; }
+        th, td { border: 1px solid var(--border); padding: 6px; }
+        th { background: var(--tag-bg); color: var(--accent-color); font-weight: 600; }
         tr.active-row { background: rgba(34, 197, 94, 0.15); }
 
         /* Workspace sandbox area */
         .workspace {
             flex-grow: 1;
             position: relative;
-            background-color: var(--bg-color);
-            background-image: radial-gradient(#27272a 1px, transparent 1px);
             background-size: 20px 20px;
             overflow: hidden;
-        }
+            background-color: var(--bg);
+            background-image: radial-gradient(var(--border) 1px, transparent 1px);
+            }
 
         /* Gates/Nodes */
         .gate {
             position: absolute;
-            background: var(--gate-bg);
-            border: 1.5px solid var(--gate-border);
+            background: var(--bg);
+            border: 1.5px solid var(--border);
             border-radius: 8px;
             padding: 5px 10px;
             min-width: 75px;
@@ -142,7 +160,7 @@
             font-weight: 700; 
             pointer-events: none; 
             margin: 0 auto;
-            color: #d4d4d8;
+            color: var(--text);
         }
 
         /* Terminals (Connection Nodes) */
@@ -193,23 +211,27 @@
         /* Toolbar overlay */
         .toolbar {
             position: absolute;
-            top: 15px; right: 15px;
+            top: 15px;
+            right: 150px;
             display: flex;
             gap: 8px;
-            z-index: 100;
+            z-index: 20;
         }
         .action-btn {
-            background: #1f1f23; 
-            color: #d4d4d8; 
-            border: 1px solid #27272a; 
+            background: var(--bg);
             padding: 6px 12px; 
             border-radius: 6px; 
             cursor: pointer;
             font-size: 0.75rem;
             font-weight: 600;
             transition: all 0.15s;
+            color: var(--text);
+            border: 1px solid var(--border);
         }
-        .action-btn:hover { background: #27272a; color: #fff; }
+        .action-btn:hover { 
+            background: var(--tag-bg);
+            color: var(--text);
+        }
         .action-btn.delete { 
             background: #7f1d1d; 
             border-color: #991b1b; 
@@ -218,6 +240,15 @@
         .action-btn.delete:hover {
             background: #991b1b;
             color: #fff;
+        }
+
+        footer a {
+            color: var(--text);
+            text-decoration: none;
+        }
+
+        footer a:hover {
+            text-decoration: underline;
         }
     
     </style>
@@ -228,6 +259,9 @@
 
     <div class="sidebar">
         <h2>Logic Lab</h2>
+        <button class="dark-mode-toggle" onclick="toggleTheme()" id="themeBtn">
+            DARK MODE
+        </button>
         <p class="desc">Drag components. Click output, then input to wire. Click wires or gates to select and delete.</p>
 
         <div class="component-list">
@@ -246,9 +280,13 @@
             <h3>Truth Table</h3>
             <button class="action-btn" style="width:100%; margin-bottom:12px;" onclick="generateTable()">Generate Table</button>
             <div id="table-output">
-                <p style="text-align:center; color:#52525b; font-size:0.75rem;">Add Inputs and Outputs to generate truth table.</p>
+                <p style="text-align:center; color:var(--muted); font-size:0.75rem;"></p>
             </div>
         </div>
+
+        <footer>
+            <a href="../../index.html">&larr; Back to Home</a>
+        </footer>
     </div>
 
     <div class="workspace" id="workspace">
@@ -257,6 +295,7 @@
             <button class="action-btn delete" id="delete-btn" style="display: none;" onclick="deleteSelected()">Delete Selected</button>
             <button class="action-btn" onclick="clearWorkspace()">Clear All</button>
         </div>
+        
     </div>
 
     <script>
@@ -435,7 +474,7 @@
         function toggleSwitch(gate) {
             gate.output = !gate.output;
             gate.element.querySelector('.gate-title').innerText = gate.output ? "1" : "0";
-            gate.element.querySelector('.gate-title').style.color = gate.output ? "#22c55e" : "#d4d4d8";
+          gate.element.querySelector('.gate-title').style.color = gate.output ? "#22c55e" : "var(--text)";
             simulate();
         }
 
@@ -723,8 +762,5 @@
             }, 50);
         };
     </script>
-    <footer>
-        <a href="../../index.html">&larr; Back to Home</a>
-    </footer>
 </body>
 </html>

--- a/tools/mesh-studio/mesh_core.html
+++ b/tools/mesh-studio/mesh_core.html
@@ -31,6 +31,7 @@
         }
 
         * { margin: 0; padding: 0; box-sizing: border-box; font-family: var(--font); }
+
         
         body { background: var(--bg); color: var(--text-main); height: 100vh; overflow: hidden; display: flex; }
 
@@ -58,7 +59,7 @@
         
         .view-title { 
             border-bottom: 1px solid var(--border); padding-bottom: 15px; margin-bottom: 25px;
-            font-size: 1.2rem; color: #fff; text-transform: uppercase; letter-spacing: 2px;
+            font-size: 1.2rem; color: var(--border); text-transform: uppercase; letter-spacing: 2px;
         }
 
         /* GRID SYSTEM */
@@ -111,7 +112,9 @@
     <script src="../../theme.js"></script>
 </head>
 <body>
-
+    <button class="dark-mode-toggle" id="themeBtn" onclick="toggleTheme()">
+    DARK MODE
+</button>
     <aside class="sidebar">
         <div class="brand-header">MESH<span>_STUDIO</span></div>
         <nav>
@@ -180,6 +183,10 @@
                 </div>
             </div>
         </section>
+
+        <footer>
+        <a href="../../index.html">&larr; Back to Home</a>
+    </footer>
 
         <section id="view-browser" class="view">
             <h2 class="view-title">VIRTUAL ROUTER</h2>

--- a/tools/pdf-organizer/pdf-organizer.html
+++ b/tools/pdf-organizer/pdf-organizer.html
@@ -36,6 +36,19 @@
         .footer-actions { margin-top: 30px; display: flex; justify-content: flex-end; }
         #exportBtn { padding: 15px 40px; background: #000; color: #fff; border: none; font-weight: 900; text-transform: uppercase; cursor: pointer; }
         #exportBtn:disabled { background: #ccc; cursor: not-allowed; }
+        footer {
+            margin-top: 20px;
+        }
+
+        footer a {
+            color: var(--text);
+            text-decoration: none;
+            border-bottom: 1px dotted var(--border);
+        }
+
+        footer a:hover {
+            opacity: 0.8;
+        }
     
     </style>
     <link rel="stylesheet" href="../../theme.css">

--- a/tools/pdf-signer/pdf-signer.html
+++ b/tools/pdf-signer/pdf-signer.html
@@ -34,7 +34,21 @@
         #scribble-pad { border: 3px solid var(--border); width: 100%; height: 300px; touch-action: none; cursor: crosshair; }
         .action-btn { width: 100%; padding: 15px; margin-top: 10px; font-family: inherit; font-weight: 900; text-transform: uppercase; background: #000; color: #fff; border: 3px solid var(--border); cursor: pointer; }
         .action-btn:disabled { background: #ccc; border-color: #ccc; cursor: not-allowed; }
-    
+
+        footer {
+            margin-top: 20px;
+        }
+
+        footer a {
+            color: var(--text);
+            text-decoration: none;
+            border-bottom: 1px dotted var(--border);
+        }
+
+        footer a:hover {
+            opacity: 0.8;
+        }
+            
     </style>
     <link rel="stylesheet" href="../../theme.css">
     <script src="../../theme.js"></script>

--- a/tools/pdf-toolkit/pdf_studio.html
+++ b/tools/pdf-toolkit/pdf_studio.html
@@ -20,9 +20,6 @@
     
     <link rel="stylesheet" href="../../assets/css/notifications.css">
     <script src="../../assets/js/notifications.js" defer></script>
-    <footer>
-        <p><a href="../../index.html">← Back to Home</a></p>
-    </footer>
     <style>
 
         * {
@@ -33,8 +30,8 @@
 
         body {
             font-family: 'Courier New', monospace;
-            background: #000;
-            color: #fff;
+            background: var(--bg);
+            color: var(--text);
             overflow: hidden;
         }
 
@@ -53,8 +50,8 @@
         }
 
         .sidebar-header {
-            background: #000;
-            color: #fff;
+            background: var(--bg);
+            color: var(--text);
             padding: 20px;
             border-bottom: 4px solid var(--border);
         }
@@ -86,9 +83,9 @@
         }
 
         .tool-item.active {
-            background: #000;
-            color: #fff;
-            box-shadow: inset 4px 0 0 #fff;
+            background: var(--bg);
+            color: var(--text);
+            box-shadow: inset 4px 0 0 var(--border);
         }
 
         .tool-item::before {
@@ -110,8 +107,8 @@
         }
 
         .header {
-            background: #000;
-            border-bottom: 4px solid #fff;
+            background: var(--bg);
+            border-bottom: 4px solid var(--border);
             padding: 20px 30px;
             display: flex;
             justify-content: space-between;
@@ -134,6 +131,7 @@
             box-shadow: 4px 4px 0 var(--border);
             transition: all 0.1s;
             font-size: 14px;
+            margin-right: 120px;
         }
 
         .btn:hover {
@@ -147,10 +145,10 @@
         }
 
         .btn-primary {
-            background: #000;
-            color: #fff;
-            border: 3px solid #fff;
-            box-shadow: 4px 4px 0 #fff;
+            background: var(--bg);
+            color: var(--text);
+            border: 3px solid var(--border);
+            box-shadow: 4px 4px 0 var(--border);
         }
 
         .btn-primary:hover {
@@ -173,7 +171,7 @@
             flex: 1;
             display: flex;
             overflow: hidden;
-            background: #1a1a1a;
+            background: var(--bg);
         }
 
         .preview-area {
@@ -312,8 +310,8 @@
 
         /* FOOTER */
         .footer {
-            background: #000;
-            border-top: 4px solid #fff;
+            background: var(--bg);
+            border-top: 4px solid var(--border);
             padding: 15px 30px;
             display: flex;
             gap: 10px;
@@ -323,7 +321,7 @@
 
         .footer-info {
             margin-left: auto;
-            color: #fff;
+            color: var(--text);
             font-size: 12px;
         }
 
@@ -563,6 +561,41 @@
             transition: transform 0.2s ease;
         }
     
+        .dark-mode-toggle {
+            margin-top: 12px;
+            padding: 8px 12px;
+            border: 2px solid var(--border);
+            background: var(--bg);
+            color: var(--text);
+            cursor: pointer;
+            font-family: inherit;
+            font-size: 0.8rem;
+            text-transform: uppercase;
+        }
+
+        .dark-mode-toggle:hover {
+            background: var(--text);
+            color: var(--bg);
+        }
+
+        .sidebar-footer {
+            padding: 20px;
+            border-top: 4px solid var(--border);
+        }
+
+        .back-home {
+            color: var(--text);
+            text-decoration: none;
+            font-size: 1rem;
+            font-weight: bold;
+            text-transform: uppercase;
+            border-bottom: 1px dotted var(--border);
+            transition: opacity 0.2s ease;
+        }
+
+        .back-home:hover {
+            opacity: 0.7;
+        }
     </style>
     <link rel="stylesheet" href="../../theme.css">
     <script src="../../theme.js"></script>
@@ -573,6 +606,11 @@
         <div class="sidebar">
             <div class="sidebar-header">
                 <h1>PDF STUDIO</h1>
+                <button class="dark-mode-toggle"
+                    onclick="toggleTheme()"
+                    id="themeBtn">
+                DARK MODE
+            </button>
             </div>
             <ul class="tool-list">
                 <li class="tool-item active" data-tool="viewer">PDF VIEWER</li>
@@ -586,6 +624,12 @@
                 <li class="tool-item" data-tool="extract">PAGE EXTRACTOR</li>
                 <li class="tool-item" data-tool="rotate">PAGE ROTATOR</li>
             </ul>
+
+            <div class="sidebar-footer">
+                <a href="../../index.html" class="back-home">
+                    ← BACK TO HOME
+                </a>
+            </div>
         </div>
 
         <!-- MAIN CONTENT -->
@@ -614,6 +658,7 @@
                     <span id="page-info"></span>
                     <span id="file-size" style="margin-left: 20px;"></span>
                 </div>
+                
             </div>
         </div>
     </div>

--- a/tools/regex-crossword/regex-crossword.html
+++ b/tools/regex-crossword/regex-crossword.html
@@ -25,10 +25,10 @@
 
         body {
             font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
-            background-color: var(--bg-color);
-            color: var(--text-color);
+            background-color: var(--bg);
+            color: var(--text);
             margin: 0;
-            padding: 20px;
+            padding: 30px;
             display: flex;
             flex-direction: column;
             align-items: center;
@@ -37,7 +37,47 @@
 
         h1 { margin-bottom: 10px; }
         p.subtitle { color: var(--muted); margin-top: -10px; margin-bottom: 30px; }
+        .main-content {
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            gap: 24px;
+        }
 
+        .header {
+            width: 100%;
+            max-width: 900px;
+            display: flex;
+            justify-content: center;
+            align-items: center;
+            position: relative;
+            margin-bottom: 40px;
+            text-align: center;
+        }
+
+        .dark-mode-toggle {
+            margin-top: 12px;
+            padding: 8px 12px;
+            border: 2px solid var(--border);
+            background: var(--bg);
+            color: var(--text);
+            cursor: pointer;
+            font-family: inherit;
+            font-size: 0.8rem;
+            text-transform: uppercase;
+        }
+
+        .dark-mode-toggle:hover {
+            background: var(--text);
+            color: var(--bg);
+        }
+
+        @media (max-width: 600px) {
+            .header {
+                flex-direction: column;
+                gap: 10px;
+            }
+        }
         .controls {
             margin-bottom: 30px;
             display: flex;
@@ -64,8 +104,9 @@
         .game-container {
             display: grid;
             gap: 10px;
-            margin-bottom: 20px;
-            /* Grid Template columns set dynamically by JS */
+            padding: 25px;
+            border-radius: 16px;
+            background: rgba(255,255,255,0.03);
         }
 
         .cell {
@@ -118,29 +159,51 @@
         }
         .confetti { font-size: 3rem; margin-bottom: 10px; }
 
-    
+        footer a {
+            color: var(--accent-color);
+            text-decoration: none;
+            font-size: 1rem;
+            font-weight: 600;
+        }
+
+        footer a:hover {
+            text-decoration: underline;
+        }
+            
     </style>
     <link rel="stylesheet" href="../../theme.css">
     <script src="../../theme.js"></script>
 </head>
 <body>
 
-    <h1>Regex Crossword</h1>
-    <p class="subtitle">Solve the puzzle by matching the patterns.</p>
-
-    <div class="controls">
-        <label>Level:</label>
-        <select id="level-select">
-            <option value="0">1. Tutorial (2x2)</option>
-            <option value="1">2. Beginner (2x2)</option>
-            <option value="2">3. Intermediate (3x3)</option>
-            <option value="3">4. Advanced (3x3)</option>
-        </select>
-        <button onclick="resetLevel()">↺ Reset</button>
-    </div>
-
-    <div id="game-board" class="game-container">
+    <div class="header">
+        <div>
+            <h1>Regex Crossword</h1>
+            <p class="subtitle">Solve the puzzle by matching the patterns.</p>
         </div>
+
+        <button class="dark-mode-toggle" onclick="toggleTheme()" id="themeBtn">
+            DARK MODE
+        </button>
+    </div>
+    <div class="main-content">
+        <div class="controls">
+            <label>Level:</label>
+            <select id="level-select">
+                <option value="0">1. Tutorial (2x2)</option>
+                <option value="1">2. Beginner (2x2)</option>
+                <option value="2">3. Intermediate (3x3)</option>
+                <option value="3">4. Advanced (3x3)</option>
+            </select>
+            <button onclick="resetLevel()">↺ Reset</button>
+        </div>
+
+        <div id="game-board" class="game-container">
+            </div>
+        <footer>
+            <a href="../../index.html">&larr; Back to Home</a>
+        </footer>
+    </div>
 
     <div id="victory-modal" class="modal hidden">
         <div class="confetti">🎉</div>
@@ -148,9 +211,7 @@
         <p>You matched all Regular Expressions.</p>
         <button onclick="nextLevel()">Next Level ➔</button>
     </div>
-    <footer>
-        <a href="../../index.html">&larr; Back to Home</a>
-    </footer>
+    
     <script src="crossword-logic.js"></script>
 </body>
 </html>

--- a/tools/vision-studio/vision_core.html
+++ b/tools/vision-studio/vision_core.html
@@ -92,6 +92,7 @@
         .logs { flex: 1; overflow-y: auto; padding: 10px; font-family: monospace; font-size: 0.8rem; }
         .log-line { margin-bottom: 3px; }
         .c-gpu { color: var(--accent); } .c-sys { color: var(--muted); }
+        
     
     </style>
     <link rel="stylesheet" href="../../theme.css">
@@ -101,7 +102,9 @@
 
     <aside class="sidebar">
         <div class="brand">VISION<span>_STUDIO</span></div>
-        
+        <button class="dark-mode-toggle" id="themeBtn" onclick="toggleTheme()">
+    DARK MODE
+</button>
         <div class="control-group">
             <div class="group-title">FILE</div>
             <button class="btn" onclick="document.getElementById('file-input').click()">LOAD IMAGE</button>

--- a/tools/world-time/world-time.css
+++ b/tools/world-time/world-time.css
@@ -27,7 +27,47 @@ body{
 
 }
 
+/* TEXT SHOULD FOLLOW THEME */
+body {
+    background: var(--bg);
+    color: var(--text);
+}
 
+/* ALL BOX TEXT FIX */
+.hero,
+.clock-card,
+.tool-section,
+.result-box,
+.converter-box,
+.form-grid,
+.input-group,
+.tabs,
+.dev-grid button,
+.clock-time {
+    color: var(--text);
+}
+
+/* INPUT TEXT FIX */
+input,
+select {
+    color: var(--text);
+    background: var(--tag-bg);
+}
+
+/* PLACEHOLDER FIX */
+input::placeholder {
+    color: gray;
+}
+
+/* CLOCK CARD TEXT FIX */
+.clock-card h4 {
+    color: var(--text);
+}
+
+/* BUTTON TEXT ALWAYS VISIBLE */
+button {
+    color: var(--text);
+}
 
 /* ================= HEADER ================= */
 
@@ -63,9 +103,6 @@ header {
 
 
 }
-
-
-
 
 
 .header-left {

--- a/tools/world-time/world-time.html
+++ b/tools/world-time/world-time.html
@@ -48,7 +48,7 @@ WORLD_TIME // COMPANION
 <button class="action-btn"
 onclick="toggleTheme()">
 
-TOGGLE THEME
+DARK / LIGHT THEME
 
 </button>
 


### PR DESCRIPTION
# Related Issue - #202 

# PR Description - 

This PR fixes Issue #202 by adding a consistent Light/Dark Mode toggle to all pages where it was missing.

# Changes Made - 

* Added the Light/Dark theme toggle to the following pages:

1. Glass Studio 
2. Bezier Generator 
3. World Time Companion 
4. Logic Gate Simulator 
5. Regex Crossword
6. CSS Clip-Path Generator
7. Hex Inspector 
8. Audio Trimmer
9. PDF Studio
10. Git Studio 
11. Archive Studio
12. Vision Studio 
13. Mesh Studio 


* Integrated the toggle with the existing global theme system.

* Ensured theme preference persists across page navigation and reloads.

* Maintained consistent UI/UX and responsive behavior across all updated pages.

# Testing - 

* Verified the theme toggle appears on all 13 affected pages.
* Confirmed switching between light and dark mode works correctly.
* Checked that the selected theme persists after refreshing or navigating between pages.

# Additional Notes - 

This update improves consistency across the website and provides a smoother user experience by ensuring theme controls are available on every major tool page.