### PR TITLE
fix: validate unit converter precision input

### DIFF
--- a/tools/unit-converter/script.js
+++ b/tools/unit-converter/script.js
@@ -282,6 +282,22 @@ function initializeCategory(category) {
     toValueInput.value = '';
 }
 
+
+function getValidPrecision() {
+    const DEFAULT_PRECISION = 4;
+    const precision = Number.parseInt(precisionInput.value, 10);
+
+    if (
+        Number.isNaN(precision) ||
+        precision < 0 ||
+        precision > 20
+    ) {
+        return DEFAULT_PRECISION;
+    }
+
+    return precision;
+}
+
 // Conversion Logic
 function performConversion() {
     const fromValue = parseFloat(fromValueInput.value);
@@ -304,7 +320,7 @@ function performConversion() {
         result = baseValue / category.toBase[toUnitSelect.value];
     }
 
-    const precision = parseInt(precisionInput.value);
+    const precision = getValidPrecision();
     toValueInput.value = parseFloat(result.toFixed(precision));
 
     addToHistory(

--- a/tools/unit-converter/unit-converter.html
+++ b/tools/unit-converter/unit-converter.html
@@ -431,7 +431,7 @@
 
                 <div class="precision-control">
                     <label for="precision">Decimal Places</label>
-                    <input type="number" id="precision" min="0" max="10" value="4">
+                    <input type="number" id="precision" min="0" max="20" value="4">
                 </div>
             </div>
 


### PR DESCRIPTION
## Summary

<!-- One-sentence description of what this PR does. -->

Fixed the Unit Converter precision validation bug by preventing invalid precision values from causing `toFixed()` RangeErrors and breaking conversions.

## Closes #274

<!-- Example: Closes #123 -->

## Changes

<!-- Bullet list of what changed and why. -->

* Added validation for the precision input before applying `toFixed()`
* Added a fallback precision value of `4` when the input is empty or invalid
* Prevented negative precision values from crashing the converter
* Restricted precision values to a valid range between `0` and `20`
* Updated the precision input field maximum value in HTML to match validation logic

## Testing

<!-- How did you verify this works? -->

* [ ] Added/updated tests
* [x] Tested locally (describe steps below)

## Testing Steps

1. Opened the Unit Converter tool locally using `unit-converter.html`
2. Tested valid precision values like `0`, `2`, and `10` and verified conversions work correctly
3. Tested invalid inputs:
   - Empty precision field
   - Negative values like `-1`
   - Values greater than `20`
4. Verified that conversions continue working without any `RangeError` in the browser console

## Screenshots

<!-- Add screenshots showing before/after behavior -->

### Before Fix

<img width="948" height="722" alt="image" src="https://github.com/user-attachments/assets/0aff0e1f-3f23-41cc-a8ae-af9f4050c869" />


### After Fix

<img width="917" height="722" alt="image" src="https://github.com/user-attachments/assets/c7ef2fd5-8937-4619-b776-50727f4bad15" />


## Contributor Details

* Name: Lovepreet Kaur 
* GitHub Username: love25-codes
* Program (SSoC / GSSoC / Hacktoberfest / Other): SSoC

## Checklist before requesting a review

* [x] Code follows the project's conventions
* [x] No secrets or `.env` values are committed
* [x] I have performed a self-review of my code
* [x] Documentation has been updated if needed
* [x] CI passes
* [x] Linked the related issue above