### PR TITLE
fix: support wrap-around weekday ranges in cron parser

### DIFF
--- a/tools/cron-explainer/cron.js
+++ b/tools/cron-explainer/cron.js
@@ -137,6 +137,8 @@ function parseField(expr, minVal, maxVal, nameMap = null) {
 
         // Range
 
+        // Range
+
         else if (part.includes('-')) {
 
 
@@ -157,17 +159,38 @@ function parseField(expr, minVal, maxVal, nameMap = null) {
                 !Number.isInteger(start) ||
                 !Number.isInteger(end) ||
                 start < minVal ||
-                end > maxVal ||
-                start > end
+                end > maxVal
             ) {
-
                 return null;
+            }
+
+
+            // Handle wrap-around weekday ranges
+            // Example:
+            // sat-sun => 6-0 => 6,7,0
+
+            if (start > end && maxVal === 7) {
+
+                for (let i = start; i <= maxVal; i += step) {
+                    values.add(i);
+                }
+
+
+                for (let i = minVal; i <= end; i += step) {
+                    values.add(i);
+                }
+
+
+                continue;
 
             }
 
 
-        }
+            if (start > end) {
+                return null;
+            }
 
+        }
 
 
         // Single value


### PR DESCRIPTION
## Summary

<!-- One-sentence description of what this PR does. -->

Fixes the CRON Schedule Explainer weekday range parsing issue by adding support for wrap-around day-of-week ranges such as `sat-sun` and `fri-mon`.

## Closes #262

<!-- Example: Closes #123 -->

## Changes

<!-- Bullet list of what changed and why. -->

* Updated the CRON field parser to support wrap-around weekday ranges.
* Added handling for cases where the starting weekday value is greater than the ending weekday value (example: `sat-sun` → `6-0`).
* Preserved existing weekday mappings (`sun = 0`, `sat = 6`) while expanding wrapped ranges internally.
* Prevented valid weekend and cross-week schedules from failing validation.
* Added support for numeric and named weekday wrap-around ranges.
* Kept existing validation behavior unchanged for invalid ranges in non-weekday fields.

## Testing

<!-- How did you verify this works? -->

* [ ] Added/updated tests
* [x] Tested locally (describe steps below)

## Testing Steps

1. Open `tools/cron-explainer/cron.html`.
2. Enter the CRON expression: ``` 0 12 * * sat-sun ```
3. Verify that the expression is accepted and no "Invalid Day of Week field" error is shown.
4. Tested additional cases:
- `0 12 * * mon-fri`
- `0 12 * * 6-0`

## Screenshots

<!-- Add screenshots showing the bug before and the fixed behavior -->

### Before Fix

<!-- Screenshot showing validation error for sat-sun -->

<img width="1047" height="437" alt="image" src="https://github.com/user-attachments/assets/11012bf2-23a8-4444-a89d-8a2842d754af" />


### After Fix

<!-- Screenshot showing successful parsing of sat-sun -->

<img width="1053" height="497" alt="image" src="https://github.com/user-attachments/assets/fe98359c-bd66-4ec5-bace-9ab12be1b107" />


## Contributor Details

* Name: Lovepreet Kaur
* GitHub Username: love25-codes
* Program (SSoC / GSSoC / Hacktoberfest / Other): SSoC

## Checklist before requesting a review

* [x] Code follows the project's conventions
* [x] No secrets or `.env` values are committed
* [x] I have performed a self-review of my code
* [x] Documentation has been updated if needed
* [x] CI passes
* [x] Linked the related issue above