### PR TITLE
docs: clarify local data storage in privacy manifesto

### DIFF
--- a/privacy.html
+++ b/privacy.html
@@ -180,39 +180,24 @@ li {
                 <strong>No Databases</strong>
                 We do not store passwords, configurations, or any personal input.
             </div>
+
             <div class="feature">
                 <strong>No Cloud Sync</strong>
                 Your data is never uploaded or processed remotely.
             </div>
+
             <div class="feature">
                 <strong>No Tracking</strong>
                 No cookies, analytics, or fingerprinting scripts.
             </div>
+
             <div class="feature">
                 <strong>No Logs</strong>
-<h3>Local Browser Storage</h3>
-
-<p>
-Some ToolSuite features use browser storage technologies such as
-localStorage and service worker caches to improve functionality and user experience.
-</p>
-
-<p>
-Examples may include:
-</p>
-
-<ul>
-    <li>User preferences (such as theme settings)</li>
-    <li>Draft content and work in progress</li>
-    <li>Tool-specific history and saved data</li>
-    <li>Offline asset caching for faster loading and offline support</li>
-</ul>
-
-<p>
-This information is stored locally on your device and may persist across page reloads, browser restarts, and future visits until you clear your browser storage or the application removes it.
-</p>           </div>
+                We do not collect or transmit server logs. Your interactions stay on your device.
+            </div>
         </div>
     </section>
+    
 
     <section class="card">
         <h2>Data Ownership</h2>
@@ -224,6 +209,28 @@ This information is stored locally on your device and may persist across page re
             <li><strong>Design Tools:</strong> Visual rendering uses your local GPU.</li>
             <li><strong>File Tools:</strong> Files are processed in memory without external transfer.</li>
         </ul>
+    </section>
+
+    <section class="card">
+    <h2>Local Browser Storage & Caching</h2>
+
+    <p>
+        Some ToolSuite features use browser storage technologies such as
+        localStorage and service worker caches to improve functionality and user experience.
+    </p>
+
+    <ul>
+        <li>User preferences (such as theme settings)</li>
+        <li>Draft content and work in progress</li>
+        <li>Tool-specific history and saved data</li>
+        <li>Offline asset caching for faster loading and offline support</li>
+    </ul>
+
+    <p>
+        This information is stored locally on your device and may persist across page reloads,
+        browser restarts, and future visits until you clear your browser storage or the
+        application removes it.
+    </p>
     </section>
 
     <section class="card">

--- a/privacy.html
+++ b/privacy.html
@@ -190,8 +190,27 @@ li {
             </div>
             <div class="feature">
                 <strong>No Logs</strong>
-                Your data disappears the moment you close the browser tab.
-            </div>
+<h3>Local Browser Storage</h3>
+
+<p>
+Some ToolSuite features use browser storage technologies such as
+localStorage and service worker caches to improve functionality and user experience.
+</p>
+
+<p>
+Examples may include:
+</p>
+
+<ul>
+    <li>User preferences (such as theme settings)</li>
+    <li>Draft content and work in progress</li>
+    <li>Tool-specific history and saved data</li>
+    <li>Offline asset caching for faster loading and offline support</li>
+</ul>
+
+<p>
+This information is stored locally on your device and may persist across page reloads, browser restarts, and future visits until you clear your browser storage or the application removes it.
+</p>           </div>
         </div>
     </section>
 


### PR DESCRIPTION
## Summary

## Summary

Updated the Privacy Manifesto to accurately describe browser-side data persistence.

## Changes

- Reviewed browser storage usage across the project
- Clarified the use of localStorage and service worker caches
- Explained which types of data may persist between sessions
- Removed the inaccurate statement implying all data is removed when a browser tab is closed

## Verification

- No sessionStorage usage found
- No IndexedDB usage found
- localStorage usage documented
- Service worker caching documented

Closes #249