### PR TITLE
Add howitworks button

### DIFF
--- a/tools/github-actions-generator/github-actions-generator.html
+++ b/tools/github-actions-generator/github-actions-generator.html
@@ -1,24 +1,29 @@
 <!DOCTYPE html>
 <html lang="en">
+
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>GitHub Actions Workflow Generator - Project Toolsuite</title>
-    <meta name="description" content="Generate production-ready, customized GitHub Actions workflow files visually. Support for Node.js, Python, React, Docker, GitHub Pages, and Vercel.">
+    <meta name="description"
+        content="Generate production-ready, customized GitHub Actions workflow files visually. Support for Node.js, Python, React, Docker, GitHub Pages, and Vercel.">
     <meta property="og:title" content="GitHub Actions Generator - Project Toolsuite" />
-    <meta property="og:description" content="Generate GitHub Actions workflow configurations quickly using an interactive browser-based tool." />
+    <meta property="og:description"
+        content="Generate GitHub Actions workflow configurations quickly using an interactive browser-based tool." />
     <meta property="og:image" content="https://cdn-icons-png.flaticon.com/512/3522/3522262.png" />
     <meta property="og:type" content="website" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="GitHub Actions Generator - Project Toolsuite" />
-    <meta name="twitter:description" content="Generate GitHub Actions workflow configurations quickly using an interactive browser-based tool." />
+    <meta name="twitter:description"
+        content="Generate GitHub Actions workflow configurations quickly using an interactive browser-based tool." />
     <link rel="stylesheet" href="../../theme.css">
     <link rel="stylesheet" href="github-actions-generator.css">
-    
+
     <link rel="stylesheet" href="../../assets/css/notifications.css">
     <script src="../../assets/js/notifications.js" defer></script>
     <script src="../../theme.js"></script>
 </head>
+
 <body>
 
     <header>
@@ -35,12 +40,13 @@
             <!-- Left Panel: Settings Form -->
             <div class="card">
                 <h2 class="card-title">Workflow Configurations</h2>
-                
+
                 <!-- Workflow File Name & Runner OS -->
                 <div class="form-row">
                     <div class="form-group">
                         <label for="workflowName">Workflow Name</label>
-                        <input type="text" id="workflowName" value="CI/CD Pipeline" placeholder="e.g. Build and Test" autocomplete="off" spellcheck="false">
+                        <input type="text" id="workflowName" value="CI/CD Pipeline" placeholder="e.g. Build and Test"
+                            autocomplete="off" spellcheck="false">
                     </div>
                     <div class="form-group" style="max-width: 200px;">
                         <label for="runnerOS">Runner OS</label>
@@ -74,7 +80,8 @@
                 <!-- Branches text input -->
                 <div class="form-group" id="branchGroup">
                     <label for="triggerBranches">Target Branches (comma-separated)</label>
-                    <input type="text" id="triggerBranches" value="main" placeholder="e.g. main, dev, release/*" autocomplete="off" spellcheck="false">
+                    <input type="text" id="triggerBranches" value="main" placeholder="e.g. main, dev, release/*"
+                        autocomplete="off" spellcheck="false">
                 </div>
 
                 <hr style="border: none; border-top: 1px dashed var(--border); margin: 24px 0;">
@@ -111,7 +118,7 @@
                 </div>
 
                 <!-- Dynamic Option Panels -->
-                
+
                 <!-- NODE PANEL -->
                 <div class="template-panel" id="panel-node">
                     <h3 style="margin-top: 0; text-transform: uppercase; font-size: 1rem;">Node.js Options</h3>
@@ -167,7 +174,8 @@
                         </div>
                         <div class="form-group">
                             <label for="pipCommand">Install Command</label>
-                            <input type="text" id="pipCommand" value="pip install -r requirements.txt" autocomplete="off" spellcheck="false">
+                            <input type="text" id="pipCommand" value="pip install -r requirements.txt"
+                                autocomplete="off" spellcheck="false">
                         </div>
                     </div>
                     <div class="form-group">
@@ -196,7 +204,8 @@
                         </div>
                         <div class="form-group">
                             <label for="reactBuildCmd">Build Command</label>
-                            <input type="text" id="reactBuildCmd" value="npm run build" autocomplete="off" spellcheck="false">
+                            <input type="text" id="reactBuildCmd" value="npm run build" autocomplete="off"
+                                spellcheck="false">
                         </div>
                     </div>
                     <div class="form-group">
@@ -207,40 +216,46 @@
                             <option value="ftp">FTP Server</option>
                         </select>
                     </div>
-                    
+
                     <div id="reactS3Group" class="sub-settings-panel active">
                         <div class="form-group">
                             <label for="reactS3Bucket">AWS S3 Bucket Name</label>
-                            <input type="text" id="reactS3Bucket" value="my-react-app-bucket" autocomplete="off" spellcheck="false">
+                            <input type="text" id="reactS3Bucket" value="my-react-app-bucket" autocomplete="off"
+                                spellcheck="false">
                         </div>
                         <div class="form-group">
                             <label for="reactAWSRegion">AWS Region</label>
-                            <input type="text" id="reactAWSRegion" value="us-east-1" autocomplete="off" spellcheck="false">
+                            <input type="text" id="reactAWSRegion" value="us-east-1" autocomplete="off"
+                                spellcheck="false">
                         </div>
                     </div>
-                    
+
                     <div id="reactGHPagesGroup" class="sub-settings-panel">
                         <div class="form-group">
                             <label for="reactGHBranch">Target Deploy Branch</label>
-                            <input type="text" id="reactGHBranch" value="gh-pages" autocomplete="off" spellcheck="false">
+                            <input type="text" id="reactGHBranch" value="gh-pages" autocomplete="off"
+                                spellcheck="false">
                         </div>
                     </div>
 
                     <div id="reactFTPGroup" class="sub-settings-panel">
                         <div class="form-group">
                             <label for="reactFTPServer">FTP Server Host</label>
-                            <input type="text" id="reactFTPServer" value="ftp.example.com" autocomplete="off" spellcheck="false">
+                            <input type="text" id="reactFTPServer" value="ftp.example.com" autocomplete="off"
+                                spellcheck="false">
                         </div>
                         <div class="form-group">
                             <label for="reactFTPTargetDir">FTP Remote Target Directory</label>
-                            <input type="text" id="reactFTPTargetDir" value="/public_html" autocomplete="off" spellcheck="false">
+                            <input type="text" id="reactFTPTargetDir" value="/public_html" autocomplete="off"
+                                spellcheck="false">
                         </div>
                     </div>
                 </div>
 
                 <!-- DOCKER PANEL -->
                 <div class="template-panel" id="panel-docker" style="display: none;">
-                    <h3 style="margin-top: 0; text-transform: uppercase; font-size: 1rem;">Docker Build & Push Options</h3>
+                    <h3 style="margin-top: 0; text-transform: uppercase; font-size: 1rem;">Docker Build & Push Options
+                    </h3>
                     <div class="form-row">
                         <div class="form-group">
                             <label for="dockerRegistry">Docker Registry</label>
@@ -252,56 +267,66 @@
                         </div>
                         <div class="form-group">
                             <label for="dockerImageName">Image Name</label>
-                            <input type="text" id="dockerImageName" value="myapp" placeholder="e.g. web-app" autocomplete="off" spellcheck="false">
+                            <input type="text" id="dockerImageName" value="myapp" placeholder="e.g. web-app"
+                                autocomplete="off" spellcheck="false">
                         </div>
                     </div>
-                    
+
                     <div id="dockerHubGroup" class="sub-settings-panel active">
                         <div class="form-group">
                             <label for="dockerHubUsername">Docker Hub Username Secret</label>
-                            <input type="text" id="dockerHubUsername" value="DOCKERHUB_USERNAME" autocomplete="off" spellcheck="false">
+                            <input type="text" id="dockerHubUsername" value="DOCKERHUB_USERNAME" autocomplete="off"
+                                spellcheck="false">
                         </div>
                         <div class="form-group">
                             <label for="dockerHubToken">Docker Hub Password/Token Secret</label>
-                            <input type="text" id="dockerHubToken" value="DOCKERHUB_TOKEN" autocomplete="off" spellcheck="false">
+                            <input type="text" id="dockerHubToken" value="DOCKERHUB_TOKEN" autocomplete="off"
+                                spellcheck="false">
                         </div>
                     </div>
 
                     <div id="dockerGHCRGroup" class="sub-settings-panel">
-                        <p style="font-size: 0.8rem; margin: 0 0 10px 0; color: var(--muted);">GHCR deployments use the repository's built-in <code>${{ secrets.GITHUB_TOKEN }}</code> permissions automatically.</p>
+                        <p style="font-size: 0.8rem; margin: 0 0 10px 0; color: var(--muted);">GHCR deployments use the
+                            repository's built-in <code>${{ secrets.GITHUB_TOKEN }}</code> permissions automatically.
+                        </p>
                     </div>
 
                     <div id="dockerAWSGroup" class="sub-settings-panel">
                         <div class="form-group">
                             <label for="dockerAWSRegistryId">AWS Account ID</label>
-                            <input type="text" id="dockerAWSRegistryId" value="123456789012" autocomplete="off" spellcheck="false">
+                            <input type="text" id="dockerAWSRegistryId" value="123456789012" autocomplete="off"
+                                spellcheck="false">
                         </div>
                         <div class="form-group">
                             <label for="dockerAWSRegion">AWS Region</label>
-                            <input type="text" id="dockerAWSRegion" value="us-east-1" autocomplete="off" spellcheck="false">
+                            <input type="text" id="dockerAWSRegion" value="us-east-1" autocomplete="off"
+                                spellcheck="false">
                         </div>
                     </div>
                 </div>
 
                 <!-- PAGES PANEL -->
                 <div class="template-panel" id="panel-pages" style="display: none;">
-                    <h3 style="margin-top: 0; text-transform: uppercase; font-size: 1rem;">GitHub Pages Deployment Options</h3>
+                    <h3 style="margin-top: 0; text-transform: uppercase; font-size: 1rem;">GitHub Pages Deployment
+                        Options</h3>
                     <div class="form-group">
                         <label class="checkbox-row">
                             <input type="checkbox" id="pagesBuildStep" checked>
                             Build Project first (e.g. React, Jekyll, etc.)
                         </label>
                     </div>
-                    
+
                     <div id="pagesBuildSubPanel" class="sub-settings-panel active">
                         <div class="form-row">
                             <div class="form-group">
                                 <label for="pagesBuildCmd">Build Command</label>
-                                <input type="text" id="pagesBuildCmd" value="npm run build" autocomplete="off" spellcheck="false">
+                                <input type="text" id="pagesBuildCmd" value="npm run build" autocomplete="off"
+                                    spellcheck="false">
                             </div>
                             <div class="form-group">
                                 <label for="pagesOutputDir">Upload Artifact Path</label>
-                                <input type="text" id="pagesOutputDir" value="dist" placeholder="e.g. build, dist, or ." autocomplete="off" spellcheck="false">
+                                <input type="text" id="pagesOutputDir" value="dist" placeholder="e.g. build, dist, or ."
+                                    autocomplete="off" spellcheck="false">
                             </div>
                         </div>
                     </div>
@@ -309,19 +334,23 @@
 
                 <!-- VERCEL PANEL -->
                 <div class="template-panel" id="panel-vercel" style="display: none;">
-                    <h3 style="margin-top: 0; text-transform: uppercase; font-size: 1rem;">Vercel Deployment Options</h3>
+                    <h3 style="margin-top: 0; text-transform: uppercase; font-size: 1rem;">Vercel Deployment Options
+                    </h3>
                     <div class="form-group">
                         <label for="vercelTokenName">Vercel Token Secret Name</label>
-                        <input type="text" id="vercelTokenName" value="VERCEL_TOKEN" autocomplete="off" spellcheck="false">
+                        <input type="text" id="vercelTokenName" value="VERCEL_TOKEN" autocomplete="off"
+                            spellcheck="false">
                     </div>
                     <div class="form-row">
                         <div class="form-group">
                             <label for="vercelProjectId">Vercel Project ID Secret Name</label>
-                            <input type="text" id="vercelProjectId" value="VERCEL_PROJECT_ID" autocomplete="off" spellcheck="false">
+                            <input type="text" id="vercelProjectId" value="VERCEL_PROJECT_ID" autocomplete="off"
+                                spellcheck="false">
                         </div>
                         <div class="form-group">
                             <label for="vercelOrgId">Vercel Org ID Secret Name</label>
-                            <input type="text" id="vercelOrgId" value="VERCEL_ORG_ID" autocomplete="off" spellcheck="false">
+                            <input type="text" id="vercelOrgId" value="VERCEL_ORG_ID" autocomplete="off"
+                                spellcheck="false">
                         </div>
                     </div>
                 </div>
@@ -330,37 +359,53 @@
 
             <!-- Right Panel: Live Code View & Explanation -->
             <div>
-                <!-- Code Preview Card -->
-                <div class="card" style="height: fit-content;">
-                    <h2 class="card-title">.github/workflows/ci.yml</h2>
-                    
-                    <div class="preview-container">
-                        <div class="preview-actions">
-                            <button class="btn" id="btnCopy" onclick="copyWorkflow()">Copy Workflow</button>
-                            <button class="btn" id="btnDownload" onclick="downloadWorkflow()">Download</button>
+                <div class="card" style="height: fit-content; display: flex; flex-direction: column;">
+                    <div
+                        style="display: flex; justify-content: space-between; align-items: center; border-bottom: 2px solid var(--border); padding-bottom: 12px; margin-bottom: 20px; flex-wrap: wrap; gap: 10px;">
+                        <h2 class="card-title" id="previewTitle"
+                            style="border-bottom: none; padding-bottom: 0; margin-bottom: 0; text-transform: lowercase;">
+                            .github/workflows/ci.yml</h2>
+                        <div class="radio-tab-group" style="margin-bottom: 0; display: flex; gap: 8px;"
+                            id="outputTabPicker">
+                            <label class="radio-tab-label checked" style="padding: 6px 12px; font-size: 0.75rem;">
+                                <input type="radio" name="outputTabType" value="code" checked>
+                                YAML Code
+                            </label>
+                            <label class="radio-tab-label" style="padding: 6px 12px; font-size: 0.75rem;">
+                                <input type="radio" name="outputTabType" value="explanation">
+                                How It Works
+                            </label>
                         </div>
-                        <textarea id="previewArea" class="preview-area" readonly></textarea>
-                    </div>
-                </div>
-
-                <!-- Explanation Widget Card -->
-                <div class="card" style="height: fit-content; margin-top: 24px;">
-                    <h2 class="card-title">How It Works</h2>
-                    
-                    <div class="explanation-panel">
-                        <ul class="explanation-list" id="explanationList">
-                            <!-- Injected dynamically -->
-                        </ul>
                     </div>
 
-                    <div class="secrets-info" id="secretsWidget" style="display: none;">
-                        <div class="secrets-info-title">
-                            🔒 Required Repository Secrets
+                    <!-- Code Tab -->
+                    <div id="output-tab-code" style="display: block;">
+                        <div class="preview-container">
+                            <div class="preview-actions">
+                                <button class="btn" id="btnCopy" onclick="copyWorkflow()">Copy Workflow</button>
+                                <button class="btn" id="btnDownload" onclick="downloadWorkflow()">Download</button>
+                            </div>
+                            <textarea id="previewArea" class="preview-area" readonly></textarea>
                         </div>
-                        <p style="margin: 0 0 10px 0;">Configure these values under <strong>Settings &gt; Secrets and Variables &gt; Actions</strong> in your GitHub repository:</p>
-                        <ul style="margin: 0; padding-left: 20px;" id="secretsList">
-                            <!-- Injected dynamically -->
-                        </ul>
+                    </div>
+
+                    <div id="output-tab-explanation" style="display: none;">
+                        <div class="explanation-panel" style="margin-top: 0; cursor: default;">
+                            <ul class="explanation-list" id="explanationList">
+
+                            </ul>
+                        </div>
+
+                        <div class="secrets-info" id="secretsWidget" style="display: none; cursor: default;">
+                            <div class="secrets-info-title">
+                                🔒 Required Repository Secrets
+                            </div>
+                            <p style="margin: 0 0 10px 0;">Configure these values under <strong>Settings &gt; Secrets
+                                    and Variables &gt; Actions</strong> in your GitHub repository:</p>
+                            <ul style="margin: 0; padding-left: 20px;" id="secretsList">
+                                <!-- Injected dynamically -->
+                            </ul>
+                        </div>
                     </div>
                 </div>
             </div>
@@ -369,4 +414,5 @@
 
     <script src="github-actions-generator.js"></script>
 </body>
+
 </html>

--- a/tools/github-actions-generator/github-actions-generator.js
+++ b/tools/github-actions-generator/github-actions-generator.js
@@ -8,26 +8,27 @@ document.addEventListener('DOMContentLoaded', () => {
         triggerDispatch: document.getElementById('triggerDispatch'),
         triggerBranches: document.getElementById('triggerBranches'),
         branchGroup: document.getElementById('branchGroup'),
-        
+
         templatePicker: document.getElementById('templatePicker'),
         previewArea: document.getElementById('previewArea'),
+        previewTitle: document.getElementById('previewTitle'),
         explanationList: document.getElementById('explanationList'),
         secretsWidget: document.getElementById('secretsWidget'),
         secretsList: document.getElementById('secretsList'),
-        
+
         // Node
         nodeVersion: document.getElementById('nodeVersion'),
         nodeCache: document.getElementById('nodeCache'),
         nodeLint: document.getElementById('nodeLint'),
         nodeTest: document.getElementById('nodeTest'),
         nodeBuild: document.getElementById('nodeBuild'),
-        
+
         // Python
         pythonVersion: document.getElementById('pythonVersion'),
         pipCommand: document.getElementById('pipCommand'),
         pythonLint: document.getElementById('pythonLint'),
         pythonTest: document.getElementById('pythonTest'),
-        
+
         // React
         reactNodeVersion: document.getElementById('reactNodeVersion'),
         reactBuildCmd: document.getElementById('reactBuildCmd'),
@@ -40,7 +41,7 @@ document.addEventListener('DOMContentLoaded', () => {
         reactS3Group: document.getElementById('reactS3Group'),
         reactGHPagesGroup: document.getElementById('reactGHPagesGroup'),
         reactFTPGroup: document.getElementById('reactFTPGroup'),
-        
+
         // Docker
         dockerRegistry: document.getElementById('dockerRegistry'),
         dockerImageName: document.getElementById('dockerImageName'),
@@ -51,13 +52,13 @@ document.addEventListener('DOMContentLoaded', () => {
         dockerAWSGroup: document.getElementById('dockerAWSGroup'),
         dockerAWSRegistryId: document.getElementById('dockerAWSRegistryId'),
         dockerAWSRegion: document.getElementById('dockerAWSRegion'),
-        
+
         // Pages
         pagesBuildStep: document.getElementById('pagesBuildStep'),
         pagesBuildCmd: document.getElementById('pagesBuildCmd'),
         pagesOutputDir: document.getElementById('pagesOutputDir'),
         pagesBuildSubPanel: document.getElementById('pagesBuildSubPanel'),
-        
+
         // Vercel
         vercelTokenName: document.getElementById('vercelTokenName'),
         vercelProjectId: document.getElementById('vercelProjectId'),
@@ -66,36 +67,56 @@ document.addEventListener('DOMContentLoaded', () => {
 
     let activeTemplate = 'node';
 
-    // Initialize Event Listeners
+
     setupEventListeners();
     updatePanelVisibility();
     generate();
 
     function setupEventListeners() {
-        // Inputs change trigger generator
+
         const inputElements = document.querySelectorAll('input, select');
         inputElements.forEach(el => {
             el.addEventListener('input', generate);
             el.addEventListener('change', generate);
         });
 
-        // Template Tab selection
+
         const tabs = elements.templatePicker.querySelectorAll('.radio-tab-label');
         tabs.forEach(tab => {
             tab.addEventListener('click', (e) => {
                 tabs.forEach(t => t.classList.remove('checked'));
                 tab.classList.add('checked');
-                
+
                 const radio = tab.querySelector('input[type="radio"]');
                 radio.checked = true;
                 activeTemplate = radio.value;
-                
+
                 updatePanelVisibility();
                 generate();
             });
         });
 
-        // Trigger Branches Group Toggle
+
+        const outputTabs = document.getElementById('outputTabPicker').querySelectorAll('.radio-tab-label');
+        outputTabs.forEach(tab => {
+            tab.addEventListener('click', (e) => {
+                outputTabs.forEach(t => t.classList.remove('checked'));
+                tab.classList.add('checked');
+
+                const radio = tab.querySelector('input[type="radio"]');
+                radio.checked = true;
+
+                if (radio.value === 'code') {
+                    document.getElementById('output-tab-code').style.display = 'block';
+                    document.getElementById('output-tab-explanation').style.display = 'none';
+                } else {
+                    document.getElementById('output-tab-code').style.display = 'none';
+                    document.getElementById('output-tab-explanation').style.display = 'block';
+                }
+            });
+        });
+
+
         const toggleBranchGroup = () => {
             const needsBranch = elements.triggerPush.checked || elements.triggerPR.checked;
             elements.branchGroup.style.display = needsBranch ? 'block' : 'none';
@@ -110,7 +131,7 @@ document.addEventListener('DOMContentLoaded', () => {
             elements.reactS3Group.classList.remove('active');
             elements.reactGHPagesGroup.classList.remove('active');
             elements.reactFTPGroup.classList.remove('active');
-            
+
             if (val === 's3') elements.reactS3Group.classList.add('active');
             if (val === 'ghpages') elements.reactGHPagesGroup.classList.add('active');
             if (val === 'ftp') elements.reactFTPGroup.classList.add('active');
@@ -122,7 +143,7 @@ document.addEventListener('DOMContentLoaded', () => {
             elements.dockerHubGroup.classList.remove('active');
             elements.dockerGHCRGroup.classList.remove('active');
             elements.dockerAWSGroup.classList.remove('active');
-            
+
             if (val === 'dockerhub') elements.dockerHubGroup.classList.add('active');
             if (val === 'ghcr') elements.dockerGHCRGroup.classList.add('active');
             if (val === 'aws') elements.dockerAWSGroup.classList.add('active');
@@ -154,8 +175,14 @@ document.addEventListener('DOMContentLoaded', () => {
         const wfName = elements.workflowName.value.trim() || 'CI/CD Pipeline';
         const os = elements.runnerOS.value;
         const branches = elements.triggerBranches.value.split(',').map(b => b.trim()).filter(b => b.length > 0);
-        
-        // Triggers Generation
+
+
+        const cleanedName = wfName.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/(^-|-$)/g, '') || 'ci';
+        if (elements.previewTitle) {
+            elements.previewTitle.innerText = `.github/workflows/${cleanedName}.yml`;
+        }
+
+
         let triggerYaml = '';
         if (elements.triggerPush.checked || elements.triggerPR.checked || elements.triggerDispatch.checked) {
             triggerYaml += 'on:\n';
@@ -175,7 +202,7 @@ document.addEventListener('DOMContentLoaded', () => {
                 triggerYaml += '  workflow_dispatch:\n';
             }
         } else {
-            // Default to push main if none selected
+
             triggerYaml += 'on:\n  push:\n    branches: [ "main" ]\n';
         }
 
@@ -183,7 +210,7 @@ document.addEventListener('DOMContentLoaded', () => {
         let explanationSteps = [];
         let secretsNeeded = [];
 
-        // Build Trigger explanations
+
         let triggerDesc = 'Triggered when code is ';
         const triggers = [];
         if (elements.triggerPush.checked) triggers.push('pushed');
@@ -200,7 +227,7 @@ document.addEventListener('DOMContentLoaded', () => {
             desc: triggerDesc + (trigText || 'pushed to main branch') + '.'
         });
 
-        // OS explanation
+
         explanationSteps.push({
             title: 'Execution Environment',
             desc: `Runs the job pipeline on a hosted virtual runner running <code>${os}</code>.`
@@ -215,7 +242,7 @@ document.addEventListener('DOMContentLoaded', () => {
             const build = elements.nodeBuild.checked;
 
             yaml += `jobs:\n  build-and-test:\n    runs-on: ${os}\n\n    steps:\n      - name: Checkout repository\n        uses: actions/checkout@v4\n\n`;
-            
+
             explanationSteps.push({
                 title: 'Checkout Code',
                 desc: 'Uses <code>actions/checkout@v4</code> to pull your repository files into the environment runner.'
@@ -550,7 +577,7 @@ document.addEventListener('DOMContentLoaded', () => {
     }
 
     // Copy to clipboard function
-    window.copyWorkflow = function() {
+    window.copyWorkflow = function () {
         const txt = elements.previewArea.value;
         navigator.clipboard.writeText(txt).then(() => {
             if (typeof notify !== 'undefined') {
@@ -567,12 +594,12 @@ document.addEventListener('DOMContentLoaded', () => {
     };
 
     // Download file function
-    window.downloadWorkflow = function() {
+    window.downloadWorkflow = function () {
         const txt = elements.previewArea.value;
         const blob = new Blob([txt], { type: 'text/yaml;charset=utf-8;' });
         const url = URL.createObjectURL(blob);
         const a = document.createElement('a');
-        
+
         // Make the file name fit clean patterns
         const cleanedName = elements.workflowName.value.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/(^-|-$)/g, '') || 'ci';
         a.href = url;
@@ -581,7 +608,7 @@ document.addEventListener('DOMContentLoaded', () => {
         a.click();
         document.body.removeChild(a);
         URL.revokeObjectURL(url);
-        
+
         if (typeof notify !== 'undefined') {
             notify.success(`Downloaded ${cleanedName}.yml successfully!`);
         }


### PR DESCRIPTION
## Summary

The how it works button is added next to the YAML code preview , previously it was at the bottom of the YAML code preview,
The unnecessary vertical space is removed and a tab for how it works is added.

## Related Issue

Closes   #264

## Changes


Before:
<img width="1482" height="815" alt="image" src="https://github.com/user-attachments/assets/74dd1886-a56e-4316-81ef-3b19efc1770c" />


After:


<img width="1182" height="745" alt="image" src="https://github.com/user-attachments/assets/46a77610-1c6f-4017-a578-acf510d38361" />


*

## Testing

* [ ] Added/updated tests
* [ ] Tested locally (describe steps below)

## Testing Steps

1. Ran the application locally.
2. Navigated to the GitHub Actions Workflow Generator page.
3. Switched between the **YAML Code Preview** and **How It Works** tabs.
4. Verified that both tabs have the same vertical height.
5. Confirmed that the **How It Works** content is displayed correctly and remains unchanged.

## Contributor Details

* Name: Helen 
* GitHub Username:.helen1806
* Program (SSoC / GSSoC / Hacktoberfest / Other): SSoC

## Checklist before requesting a review

* [ ] Code follows the project's conventions
* [ ] No secrets or `.env` values are committed
* [ ] I have performed a self-review of my code
* [ ] Documentation has been updated if needed
* [ ] CI passes
* [ ] Linked the related issue above