### PR TITLE
fix: prevent unit converter history flooding

### DIFF
--- a/tools/unit-converter/script.js
+++ b/tools/unit-converter/script.js
@@ -322,16 +322,35 @@ function performConversion() {
 
     const precision = getValidPrecision();
     toValueInput.value = parseFloat(result.toFixed(precision));
+}
 
-    addToHistory(
-        `${fromValue} ${fromUnitSelect.value} → ${toValueInput.value} ${toUnitSelect.value}`
-    );
+function saveCurrentToHistory() {
+    const fromValue = parseFloat(fromValueInput.value);
+    if (isNaN(fromValue)) {
+        return;
+    }
+    const entry = `${fromValue} ${fromUnitSelect.value} → ${toValueInput.value} ${toUnitSelect.value}`;
+    addToHistory(entry);
 }
 
 // Event Listeners for Conversion
 fromValueInput.addEventListener('input', performConversion);
-fromUnitSelect.addEventListener('change', performConversion);
-toUnitSelect.addEventListener('change', performConversion);
+fromValueInput.addEventListener('change', saveCurrentToHistory);
+fromValueInput.addEventListener('blur', saveCurrentToHistory);
+fromValueInput.addEventListener('keydown', (e) => {
+    if (e.key === 'Enter') {
+        saveCurrentToHistory();
+    }
+});
+
+fromUnitSelect.addEventListener('change', () => {
+    performConversion();
+    saveCurrentToHistory();
+});
+toUnitSelect.addEventListener('change', () => {
+    performConversion();
+    saveCurrentToHistory();
+});
 precisionInput.addEventListener('change', performConversion);
 
 // Swap Units
@@ -345,11 +364,16 @@ swapBtn.addEventListener('click', () => {
     toValueInput.value = tempValue;
 
     performConversion();
+    saveCurrentToHistory();
 });
 
 // History Management
 function addToHistory(entry) {
     if (entry.includes('→') && entry.split('→')[1].trim() !== '') {
+        // Prevent duplicate consecutive history entries
+        if (conversionHistory.length > 0 && conversionHistory[0] === entry) {
+            return;
+        }
         conversionHistory.unshift(entry);
         if (conversionHistory.length > 10) {
             conversionHistory.pop();


### PR DESCRIPTION
## Summary

Fixes history flooding in the Unit Converter by separating conversion calculations from history logging. Conversions continue to update live while typing, but history entries are only added when the user completes an action such as pressing Enter, blurring the input, changing units, or using the swap button.

## Related Issue

Closes #273

## Changes

* Removed history logging from `performConversion()`
* Added a dedicated `saveCurrentToHistory()` helper function
* Kept live conversion updates on the `input` event
* Added history logging on:

  * Input blur
  * Input change
  * Enter key press
  * Unit dropdown changes
  * Swap button click
* Prevented duplicate consecutive history entries

## Testing

* [x] Tested locally

## Testing Steps

1. Typed `123.45` slowly and verified no history entries were added while typing.
2. Pressed Enter and verified exactly one history entry was created.
3. Tested blur, unit changes, and swap button actions and verified a single history entry was logged.
4. Confirmed duplicate consecutive entries are ignored.
5. Verified conversion calculations continue updating in real time.

## Contributor Details

* Name: Shreya Gupta
* GitHub Username: shreyagupta2006
* Program: SSoC

## Checklist before requesting a review

* [x] Code follows the project's conventions
* [x] No secrets or `.env` values are committed
* [x] I have performed a self-review of my code
* [x] Documentation has been updated if needed
* [ ] CI passes
* [x] Linked the related issue above
