### PR TITLE
fix: remove erroneous activeTag reset in renderTools causing tag filter to not work

### DIFF
--- a/index.html
+++ b/index.html
@@ -1036,11 +1036,6 @@ function renderTags() {
 }
 
 function renderTools() {
-  const rawQuery = document.getElementById("toolSearch").value.trim();
-  if (!rawQuery) {
-    activeTag = 'all';
-    renderTags();
-  }
   const normalize = (str) => str.toLowerCase().replace(/\s+/g, "");
   const query = normalize(document.getElementById("toolSearch").value);
   const container = document.getElementById("tools-container");


### PR DESCRIPTION
## Summary

Fixes the Filter Tags section not filtering the tools list when a tag is clicked.

## Related Issue

Closes #253 

## Changes

- Removed an erroneous activeTag = 'all' reset (and accompanying renderTags() call) inside renderTools() that ran whenever the search box was empty.
- Since tag buttons call renderTools() immediately after setting activeTag, this reset was undoing the tag selection within the same click, so clicking any tag had no visible effect on the displayed tools.
- No other logic, markup, or styling was changed.

## Testing

* [ ] Added/updated tests
* [x] Tested locally (describe steps below)

## Testing Steps

1. Opened index.html locally in the browser.
2. Clicked each tag in the Filter Tags section (e.g., "Dev", "Audio", "Design") and confirmed the tools grid updates to show only matching tools, and the clicked tag is visually marked active.
3. Confirmed the search box still filters by name correctly, and that switching between search and tag filtering doesn't break either function.

## Contributor Details

* Name: Mehwish
* GitHub Username: MEHWISH310
* Program (SSoC / GSSoC / Hacktoberfest / Other): SSoC

## Checklist before requesting a review

* [x] Code follows the project's conventions
* [x] No secrets or `.env` values are committed
* [x] I have performed a self-review of my code
* [ ] Documentation has been updated if needed
* [ ] CI passes
* [x] Linked the related issue above

## Recording

https://github.com/user-attachments/assets/c40845e8-4f33-4f8c-9213-64cb586764f5