### PR TITLE
feat: automate sitemap generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,24 @@ Project-Toolsuite/
 
 ---
 
+## Sitemap Generation
+
+The sitemap is generated from the repository structure using:
+
+```bash
+python3 scripts/generate_sitemap.py
+```
+
+Run this script whenever new tool pages or static pages are added to keep `sitemap.xml` up to date.
+
+The script automatically:
+
+- Discovers tool HTML files under `tools/`
+- Includes static pages such as the homepage, privacy page, and contributors page
+- Regenerates a valid `sitemap.xml`
+
+---
+
 ## Contributing
 
 Contributions are welcome, whether you're fixing bugs, improving documentation, or building new tools.

--- a/scripts/generate_sitemap.py
+++ b/scripts/generate_sitemap.py
@@ -1,0 +1,36 @@
+from pathlib import Path
+from urllib.parse import quote
+
+BASE_URL = "https://project-toolsuite.vercel.app"
+
+STATIC_PAGES = [
+    "/",
+    "/privacy.html",
+    "/contributers.html",
+]
+
+root = Path(__file__).resolve().parent.parent
+tools_dir = root / "tools"
+
+urls = []
+
+for page in STATIC_PAGES:
+    urls.append(f"{BASE_URL}{page}")
+
+for html_file in sorted(tools_dir.glob("*/*.html")):
+    relative_path = html_file.relative_to(root).as_posix()
+    urls.append(f"{BASE_URL}/{quote(relative_path)}")
+
+xml = ['<?xml version="1.0" encoding="UTF-8"?>']
+xml.append('<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">')
+
+for url in urls:
+    xml.append("  <url>")
+    xml.append(f"    <loc>{url}</loc>")
+    xml.append("  </url>")
+
+xml.append("</urlset>")
+
+(root / "sitemap.xml").write_text("\n".join(xml), encoding="utf-8")
+
+print(f"Generated sitemap with {len(urls)} URLs")

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -1,70 +1,177 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
-<url>
-  <loc>https://project-toolsuite.vercel.app/</loc>
-</url>
-
-<url>
-  <loc>https://project-toolsuite.vercel.app/privacy.html</loc>
-</url>
-
-<url>
-  <loc>https://project-toolsuite.vercel.app/contributers.html</loc>
-</url>
-
-<url><loc>https://project-toolsuite.vercel.app/tools/aes-encryption-decryption/aes.html</loc></url>
-<url><loc>https://project-toolsuite.vercel.app/tools/api-client/api-client.html</loc></url>
-<url><loc>https://project-toolsuite.vercel.app/tools/archive-studio/archive_studio.html</loc></url>
-<url><loc>https://project-toolsuite.vercel.app/tools/audio-trimmer/audio-trimmer.html</loc></url>
-<url><loc>https://project-toolsuite.vercel.app/tools/base64/base64.html</loc></url>
-<url><loc>https://project-toolsuite.vercel.app/tools/bezier-generator/bezier.html</loc></url>
-<url><loc>https://project-toolsuite.vercel.app/tools/bulk%20watermarker/bulkwatermarker.html</loc></url>
-<url><loc>https://project-toolsuite.vercel.app/tools/cicd-visualizer/cicd-visualizer.html</loc></url>
-<url><loc>https://project-toolsuite.vercel.app/tools/clip-path-generator/clip-path.html</loc></url>
-<url><loc>https://project-toolsuite.vercel.app/tools/color%20palette%20extractor/palette.html</loc></url>
-<url><loc>https://project-toolsuite.vercel.app/tools/compiler/compiler.html</loc></url>
-<url><loc>https://project-toolsuite.vercel.app/tools/cron-explainer/cron.html</loc></url>
-<url><loc>https://project-toolsuite.vercel.app/tools/diff-checker/diff.html</loc></url>
-<url><loc>https://project-toolsuite.vercel.app/tools/email-validator/email-validator.html</loc></url>
-<url><loc>https://project-toolsuite.vercel.app/tools/exif%20scrubber/scrubber.html</loc></url>
-<url><loc>https://project-toolsuite.vercel.app/tools/favicon%20generator/favicon-generator.html</loc></url>
-<url><loc>https://project-toolsuite.vercel.app/tools/file%20converters/converter.html</loc></url>
-<url><loc>https://project-toolsuite.vercel.app/tools/git-studio/git_studio.html</loc></url>
-<url><loc>https://project-toolsuite.vercel.app/tools/github-actions-generator/github-actions-generator.html</loc></url>
-<url><loc>https://project-toolsuite.vercel.app/tools/glass%20studio/glass-studio.html</loc></url>
-<url><loc>https://project-toolsuite.vercel.app/tools/hash%20generator/hash-generator.html</loc></url>
-<url><loc>https://project-toolsuite.vercel.app/tools/hex-inspector/hex.html</loc></url>
-<url><loc>https://project-toolsuite.vercel.app/tools/image%20compressor/image-compressor.html</loc></url>
-<url><loc>https://project-toolsuite.vercel.app/tools/ip-subnet-calculator/index.html</loc></url>
-<url><loc>https://project-toolsuite.vercel.app/tools/json-formatter/json-formatter.html</loc></url>
-<url><loc>https://project-toolsuite.vercel.app/tools/jwt-debugger/jwt-debugger.html</loc></url>
-<url><loc>https://project-toolsuite.vercel.app/tools/kanban-board/kanban.html</loc></url>
-<url><loc>https://project-toolsuite.vercel.app/tools/kubernetes-manifest-generator/kubernetes-manifest-generator.html</loc></url>
-<url><loc>https://project-toolsuite.vercel.app/tools/linkedin-text-formatter/formatter.html</loc></url>
-<url><loc>https://project-toolsuite.vercel.app/tools/logic-simulator/logic.html</loc></url>
-<url><loc>https://project-toolsuite.vercel.app/tools/markdown-editor/editor.html</loc></url>
-<url><loc>https://project-toolsuite.vercel.app/tools/mesh-studio/mesh_core.html</loc></url>
-<url><loc>https://project-toolsuite.vercel.app/tools/nginx-generator/nginx-generator.html</loc></url>
-<url><loc>https://project-toolsuite.vercel.app/tools/ocr/ocr.html</loc></url>
-<url><loc>https://project-toolsuite.vercel.app/tools/password%20lab/password-tester.html</loc></url>
-<url><loc>https://project-toolsuite.vercel.app/tools/pdf%20merger/pdf-merger.html</loc></url>
-<url><loc>https://project-toolsuite.vercel.app/tools/pdf-organizer/pdf-organizer.html</loc></url>
-<url><loc>https://project-toolsuite.vercel.app/tools/pdf-signer/pdf-signer.html</loc></url>
-<url><loc>https://project-toolsuite.vercel.app/tools/pdf-toolkit/pdf_studio.html</loc></url>
-<url><loc>https://project-toolsuite.vercel.app/tools/qr%20generator/qr-generator.html</loc></url>
-<url><loc>https://project-toolsuite.vercel.app/tools/regex-crossword/regex-crossword.html</loc></url>
-<url><loc>https://project-toolsuite.vercel.app/tools/regex-tester/regex.html</loc></url>
-<url><loc>https://project-toolsuite.vercel.app/tools/rsa-encryption-decryption/rsa.html</loc></url>
-<url><loc>https://project-toolsuite.vercel.app/tools/screen%20mirror/mirror.html</loc></url>
-<url><loc>https://project-toolsuite.vercel.app/tools/screen%20recorder/recorder.html</loc></url>
-<url><loc>https://project-toolsuite.vercel.app/tools/steganography/stego.html</loc></url>
-<url><loc>https://project-toolsuite.vercel.app/tools/svg-optimizer/svg-optimizer.html</loc></url>
-<url><loc>https://project-toolsuite.vercel.app/tools/synth-sequencer/synth.html</loc></url>
-<url><loc>https://project-toolsuite.vercel.app/tools/text-to-speech/tts.html</loc></url>
-<url><loc>https://project-toolsuite.vercel.app/tools/typing-test/typing-test.html</loc></url>
-<url><loc>https://project-toolsuite.vercel.app/tools/unit-converter/unit-converter.html</loc></url>
-<url><loc>https://project-toolsuite.vercel.app/tools/url%20shortener/shortener.html</loc></url>
-<url><loc>https://project-toolsuite.vercel.app/tools/vector-studio/vector_studio.html</loc></url>
-<url><loc>https://project-toolsuite.vercel.app/tools/vision-studio/vision_core.html</loc></url>
-<url><loc>https://project-toolsuite.vercel.app/tools/world-time/world-time.html</loc></url>
+  <url>
+    <loc>https://project-toolsuite.vercel.app/</loc>
+  </url>
+  <url>
+    <loc>https://project-toolsuite.vercel.app/privacy.html</loc>
+  </url>
+  <url>
+    <loc>https://project-toolsuite.vercel.app/contributers.html</loc>
+  </url>
+  <url>
+    <loc>https://project-toolsuite.vercel.app/tools/aes-encryption-decryption/aes.html</loc>
+  </url>
+  <url>
+    <loc>https://project-toolsuite.vercel.app/tools/api-client/api-client.html</loc>
+  </url>
+  <url>
+    <loc>https://project-toolsuite.vercel.app/tools/archive-studio/archive_studio.html</loc>
+  </url>
+  <url>
+    <loc>https://project-toolsuite.vercel.app/tools/audio-trimmer/audio-trimmer.html</loc>
+  </url>
+  <url>
+    <loc>https://project-toolsuite.vercel.app/tools/base64/base64.html</loc>
+  </url>
+  <url>
+    <loc>https://project-toolsuite.vercel.app/tools/bezier-generator/bezier.html</loc>
+  </url>
+  <url>
+    <loc>https://project-toolsuite.vercel.app/tools/bulk%20watermarker/bulkwatermarker.html</loc>
+  </url>
+  <url>
+    <loc>https://project-toolsuite.vercel.app/tools/cicd-visualizer/cicd-visualizer.html</loc>
+  </url>
+  <url>
+    <loc>https://project-toolsuite.vercel.app/tools/clip-path-generator/clip-path.html</loc>
+  </url>
+  <url>
+    <loc>https://project-toolsuite.vercel.app/tools/color%20palette%20extractor/palette.html</loc>
+  </url>
+  <url>
+    <loc>https://project-toolsuite.vercel.app/tools/compiler/compiler.html</loc>
+  </url>
+  <url>
+    <loc>https://project-toolsuite.vercel.app/tools/cron-explainer/cron.html</loc>
+  </url>
+  <url>
+    <loc>https://project-toolsuite.vercel.app/tools/diff-checker/diff.html</loc>
+  </url>
+  <url>
+    <loc>https://project-toolsuite.vercel.app/tools/email-validator/email-validator.html</loc>
+  </url>
+  <url>
+    <loc>https://project-toolsuite.vercel.app/tools/exif%20scrubber/scrubber.html</loc>
+  </url>
+  <url>
+    <loc>https://project-toolsuite.vercel.app/tools/favicon%20generator/favicon-generator.html</loc>
+  </url>
+  <url>
+    <loc>https://project-toolsuite.vercel.app/tools/file%20converters/converter.html</loc>
+  </url>
+  <url>
+    <loc>https://project-toolsuite.vercel.app/tools/git-studio/git_studio.html</loc>
+  </url>
+  <url>
+    <loc>https://project-toolsuite.vercel.app/tools/github-actions-generator/github-actions-generator.html</loc>
+  </url>
+  <url>
+    <loc>https://project-toolsuite.vercel.app/tools/glass%20studio/glass-studio.html</loc>
+  </url>
+  <url>
+    <loc>https://project-toolsuite.vercel.app/tools/hash%20generator/hash-generator.html</loc>
+  </url>
+  <url>
+    <loc>https://project-toolsuite.vercel.app/tools/hex-inspector/hex.html</loc>
+  </url>
+  <url>
+    <loc>https://project-toolsuite.vercel.app/tools/image%20compressor/image-compressor.html</loc>
+  </url>
+  <url>
+    <loc>https://project-toolsuite.vercel.app/tools/ip-subnet-calculator/index.html</loc>
+  </url>
+  <url>
+    <loc>https://project-toolsuite.vercel.app/tools/json-formatter/json-formatter.html</loc>
+  </url>
+  <url>
+    <loc>https://project-toolsuite.vercel.app/tools/jwt-debugger/jwt-debugger.html</loc>
+  </url>
+  <url>
+    <loc>https://project-toolsuite.vercel.app/tools/kanban-board/kanban.html</loc>
+  </url>
+  <url>
+    <loc>https://project-toolsuite.vercel.app/tools/kubernetes-manifest-generator/kubernetes-manifest-generator.html</loc>
+  </url>
+  <url>
+    <loc>https://project-toolsuite.vercel.app/tools/linkedin-text-formatter/formatter.html</loc>
+  </url>
+  <url>
+    <loc>https://project-toolsuite.vercel.app/tools/logic-simulator/logic.html</loc>
+  </url>
+  <url>
+    <loc>https://project-toolsuite.vercel.app/tools/markdown-editor/editor.html</loc>
+  </url>
+  <url>
+    <loc>https://project-toolsuite.vercel.app/tools/mesh-studio/mesh_core.html</loc>
+  </url>
+  <url>
+    <loc>https://project-toolsuite.vercel.app/tools/nginx-generator/nginx-generator.html</loc>
+  </url>
+  <url>
+    <loc>https://project-toolsuite.vercel.app/tools/ocr/ocr.html</loc>
+  </url>
+  <url>
+    <loc>https://project-toolsuite.vercel.app/tools/password%20lab/password-tester.html</loc>
+  </url>
+  <url>
+    <loc>https://project-toolsuite.vercel.app/tools/pdf%20merger/pdf-merger.html</loc>
+  </url>
+  <url>
+    <loc>https://project-toolsuite.vercel.app/tools/pdf-organizer/pdf-organizer.html</loc>
+  </url>
+  <url>
+    <loc>https://project-toolsuite.vercel.app/tools/pdf-signer/pdf-signer.html</loc>
+  </url>
+  <url>
+    <loc>https://project-toolsuite.vercel.app/tools/pdf-toolkit/pdf_studio.html</loc>
+  </url>
+  <url>
+    <loc>https://project-toolsuite.vercel.app/tools/qr%20generator/qr-generator.html</loc>
+  </url>
+  <url>
+    <loc>https://project-toolsuite.vercel.app/tools/regex-crossword/regex-crossword.html</loc>
+  </url>
+  <url>
+    <loc>https://project-toolsuite.vercel.app/tools/regex-tester/regex.html</loc>
+  </url>
+  <url>
+    <loc>https://project-toolsuite.vercel.app/tools/rsa-encryption-decryption/rsa.html</loc>
+  </url>
+  <url>
+    <loc>https://project-toolsuite.vercel.app/tools/screen%20mirror/mirror.html</loc>
+  </url>
+  <url>
+    <loc>https://project-toolsuite.vercel.app/tools/screen%20recorder/recorder.html</loc>
+  </url>
+  <url>
+    <loc>https://project-toolsuite.vercel.app/tools/steganography/stego.html</loc>
+  </url>
+  <url>
+    <loc>https://project-toolsuite.vercel.app/tools/svg-optimizer/svg-optimizer.html</loc>
+  </url>
+  <url>
+    <loc>https://project-toolsuite.vercel.app/tools/synth-sequencer/synth.html</loc>
+  </url>
+  <url>
+    <loc>https://project-toolsuite.vercel.app/tools/text-to-speech/tts.html</loc>
+  </url>
+  <url>
+    <loc>https://project-toolsuite.vercel.app/tools/typing-test/typing-test.html</loc>
+  </url>
+  <url>
+    <loc>https://project-toolsuite.vercel.app/tools/unit-converter/unit-converter.html</loc>
+  </url>
+  <url>
+    <loc>https://project-toolsuite.vercel.app/tools/url%20shortener/shortener.html</loc>
+  </url>
+  <url>
+    <loc>https://project-toolsuite.vercel.app/tools/vector-studio/vector_studio.html</loc>
+  </url>
+  <url>
+    <loc>https://project-toolsuite.vercel.app/tools/vision-studio/vision_core.html</loc>
+  </url>
+  <url>
+    <loc>https://project-toolsuite.vercel.app/tools/world-time/world-time.html</loc>
+  </url>
 </urlset>


### PR DESCRIPTION
## Summary

Automates sitemap maintenance by introducing a sitemap generation script that discovers tool pages directly from the repository structure.

## Problem

The existing `sitemap.xml` is manually maintained. Whenever a new tool or page is added, contributors must remember to update the sitemap, which increases maintenance overhead and creates a risk of missing routes.

## Changes Made

* Added `scripts/generate_sitemap.py`
* Automatically discovers tool HTML files under `tools/`
* Includes static pages such as:

  * Homepage
  * Privacy page
  * Contributors page
* Generates a valid `sitemap.xml`
* Added README documentation explaining how to regenerate the sitemap

## Benefits

* Eliminates manual sitemap editing
* Keeps sitemap synchronized with repository structure
* Reduces the risk of missing routes
* Improves long-term maintainability

## Verification

* Script successfully generated a sitemap containing all current routes
* Generated sitemap includes:

  * 55 tool pages
  * 3 static pages
* Total URLs generated: 58
* Regenerating the sitemap produces consistent output

Closes #297
