### PR TITLE
feat: add aria-live region for tool count accessibility

### DIFF
--- a/index.html
+++ b/index.html
@@ -713,7 +713,7 @@
             aria-label="Search tools"
             autofocus
           />
-          <p id="toolCount"></p>
+         <p id="toolCount" role="status" aria-live="polite"></p>
 
           <div class="tools-grid" id="tools-container">
             <!-- Tools will be injected here -->


### PR DESCRIPTION
## Summary

Improves accessibility by adding a live region to the tool count element so screen readers announce updates when filters or search results change.

## Closes #301

<!-- Example: Closes #123 -->

## Changes

- Added `aria-live="polite"` and `role="status"` to `#toolCount` element
- Ensures dynamic updates to tool count are announced by assistive technologies
- No changes to UI layout or JavaScript logic

## Testing

- [ ] Added/updated tests (not required for this UI-only change)
- [x] Tested locally (verified in browser and DevTools Accessibility panel)

## Testing Steps

1. Open the homepage in browser  
2. Type in the search bar (e.g., "pdf", "dev", "security")  
3. Observe tool count updates dynamically  
4. Open DevTools → Accessibility tab and inspect `#toolCount`  
5. Confirm:
   - role = status  
   - aria-live = polite  

## Screenshots

### Before
- Tool count updates visually only
- No ARIA live region present
- Screen readers do not announce changes

<img width="820" height="582" alt="image" src="https://github.com/user-attachments/assets/873dff53-7c64-4c80-bc00-8663a5fb8c9a" />


### After
- Tool count updates are announced by screen readers
- DevTools shows:
  - role: status  
  - aria-live: polite  

<img width="822" height="578" alt="image" src="https://github.com/user-attachments/assets/9d1017e9-0f70-44d1-b3fd-98e41ba62683" />

## Contributor Details

* Name: Lovepreet Kaur
* GitHub Username: love25-codes
* Program (SSoC / GSSoC / Hacktoberfest / Other): SSoC

## Checklist before requesting a review

- [x] Code follows the project's conventions
- [x] No secrets or `.env` values are committed
- [x] I have performed a self-review of my code
- [x] Documentation has been updated if needed
- [x] CI passes
- [x] Linked the related issue above