### PR TITLE
fix: add aria-labels to copy action buttons

### DIFF
--- a/tools/ip-subnet-calculator/index.html
+++ b/tools/ip-subnet-calculator/index.html
@@ -98,7 +98,7 @@
                         <span class="result-label">Network Address</span>
                         <div class="result-value-wrapper">
                             <span id="resNetwork" class="result-value">192.168.1.0</span>
-                            <button class="copy-btn" title="Copy to clipboard" data-target="resNetwork">
+                            <button class="copy-btn" aria-label="Copy network address" title="Copy to clipboard" data-target="resNetwork">
                                 <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="9" y="9" width="13" height="13" rx="2" ry="2"></rect><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"></path></svg>
                             </button>
                         </div>
@@ -108,7 +108,7 @@
                         <span class="result-label">Broadcast Address</span>
                         <div class="result-value-wrapper">
                             <span id="resBroadcast" class="result-value">192.168.1.255</span>
-                            <button class="copy-btn" title="Copy to clipboard" data-target="resBroadcast">
+                            <button class="copy-btn" aria-label="Copy broadcast address" title="Copy to clipboard" data-target="resBroadcast">
                                 <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="9" y="9" width="13" height="13" rx="2" ry="2"></rect><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"></path></svg>
                             </button>
                         </div>
@@ -118,7 +118,7 @@
                         <span class="result-label">First Usable Host</span>
                         <div class="result-value-wrapper">
                             <span id="resFirstHost" class="result-value">192.168.1.1</span>
-                            <button class="copy-btn" title="Copy to clipboard" data-target="resFirstHost">
+                            <button class="copy-btn" aria-label="Copy first host address" title="Copy to clipboard" data-target="resFirstHost">
                                 <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="9" y="9" width="13" height="13" rx="2" ry="2"></rect><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"></path></svg>
                             </button>
                         </div>
@@ -128,7 +128,7 @@
                         <span class="result-label">Last Usable Host</span>
                         <div class="result-value-wrapper">
                             <span id="resLastHost" class="result-value">192.168.1.254</span>
-                            <button class="copy-btn" title="Copy to clipboard" data-target="resLastHost">
+                            <button class="copy-btn" aria-label="Copy last host address" title="Copy to clipboard" data-target="resLastHost">
                                 <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="9" y="9" width="13" height="13" rx="2" ry="2"></rect><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"></path></svg>
                             </button>
                         </div>
@@ -138,7 +138,7 @@
                         <span class="result-label">Subnet Mask</span>
                         <div class="result-value-wrapper">
                             <span id="resSubnetMask" class="result-value">255.255.255.0</span>
-                            <button class="copy-btn" title="Copy to clipboard" data-target="resSubnetMask">
+                            <button class="copy-btn" aria-label="Copy subnet mask" title="Copy to clipboard" data-target="resSubnetMask">
                                 <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="9" y="9" width="13" height="13" rx="2" ry="2"></rect><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"></path></svg>
                             </button>
                         </div>
@@ -148,7 +148,7 @@
                         <span class="result-label">CIDR Prefix</span>
                         <div class="result-value-wrapper">
                             <span id="resCidr" class="result-value">/24</span>
-                            <button class="copy-btn" title="Copy to clipboard" data-target="resCidr">
+                            <button class="copy-btn" aria-label="Copy CIDR notation" title="Copy to clipboard" data-target="resCidr">
                                 <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="9" y="9" width="13" height="13" rx="2" ry="2"></rect><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"></path></svg>
                             </button>
                         </div>
@@ -158,7 +158,7 @@
                         <span class="result-label">Total Addresses</span>
                         <div class="result-value-wrapper">
                             <span id="resTotalHosts" class="result-value">256</span>
-                            <button class="copy-btn" title="Copy to clipboard" data-target="resTotalHosts">
+                            <button class="copy-btn" aria-label="Copy total hosts" title="Copy to clipboard" data-target="resTotalHosts">
                                 <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="9" y="9" width="13" height="13" rx="2" ry="2"></rect><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"></path></svg>
                             </button>
                         </div>
@@ -168,7 +168,7 @@
                         <span class="result-label">Usable Hosts</span>
                         <div class="result-value-wrapper">
                             <span id="resUsableHosts" class="result-value">254</span>
-                            <button class="copy-btn" title="Copy to clipboard" data-target="resUsableHosts">
+                            <button class="copy-btn" aria-label="Copy usable hosts" title="Copy to clipboard" data-target="resUsableHosts">
                                 <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="9" y="9" width="13" height="13" rx="2" ry="2"></rect><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"></path></svg>
                             </button>
                         </div>


### PR DESCRIPTION
## Summary

This PR improves accessibility by adding explicit `aria-label` attributes to icon-only copy buttons in the IP Subnet Calculator.

### Changes Made

* Added descriptive `aria-label` attributes to all icon-only copy buttons.
* Preserved the existing `title` attribute and visual appearance.
* Improved screen reader support by providing meaningful accessible names for each copy action.

### Buttons Updated

* Copy network address
* Copy broadcast address
* Copy first host address
* Copy last host address
* Copy subnet mask
* Copy CIDR notation
* Copy total hosts
* Copy usable hosts

### Benefits

* Improves accessibility for screen reader users.
* Provides reliable accessible names instead of relying solely on the `title` attribute.
* Maintains the existing UI and functionality.

closes #303