### PR TITLE
feat(base64): add export output functionality

### DIFF
--- a/tools/base64/base64-logic.js
+++ b/tools/base64/base64-logic.js
@@ -4,7 +4,9 @@ const input = document.getElementById('input');
 const output = document.getElementById('output');
 const encodeBtn = document.getElementById('encodeBtn');
 const decodeBtn = document.getElementById('decodeBtn');
-
+const exportTxtBtn = document.getElementById('exportTxtBtn');
+const exportJsonBtn = document.getElementById('exportJsonBtn');
+const exportPdfBtn = document.getElementById('exportPdfBtn');
 
 function encodeBase64(str) {
     return btoa(
@@ -25,13 +27,20 @@ function decodeBase64(str) {
 
 function updateButtonState() {
     const hasInput = input.value.trim().length > 0;
+    const hasOutput = output.value.trim().length > 0;
+
     encodeBtn.disabled = !hasInput;
     decodeBtn.disabled = !hasInput;
+
+    exportTxtBtn.disabled = !hasOutput;
+    exportJsonBtn.disabled = !hasOutput;
+    exportPdfBtn.disabled = !hasOutput;
 }
 
 encodeBtn.onclick = () => {
     try {
         output.value = encodeBase64(input.value);
+updateButtonState();
     } catch {
         notify.error('Unable to encode this text.');
     }
@@ -40,11 +49,84 @@ encodeBtn.onclick = () => {
 decodeBtn.onclick = () => {
     try {
         output.value = decodeBase64(input.value.trim());
+updateButtonState();
     } catch {
         notify.error('Invalid Base64 string.');
     }
 };
-
-input.addEventListener('input', updateButtonState);
+input.addEventListener('input', () => {
+    output.value = '';
+    updateButtonState();
+});
 
 updateButtonState();
+// ---------- Export Helpers ----------
+
+function hasOutput() {
+    if (!output.value.trim()) {
+        notify.error('Nothing to export.');
+        return false;
+    }
+    return true;
+}
+
+// TXT Export
+exportTxtBtn.onclick = () => {
+    if (!hasOutput()) return;
+
+    const blob = new Blob([output.value], { type: 'text/plain' });
+    const url = URL.createObjectURL(blob);
+
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = 'base64-output.txt';
+    a.click();
+
+    URL.revokeObjectURL(url);
+};
+
+// JSON Export
+exportJsonBtn.onclick = () => {
+    if (!hasOutput()) return;
+
+    const data = {
+        input: input.value,
+        output: output.value,
+        exportedAt: new Date().toISOString()
+    };
+
+    const blob = new Blob(
+        [JSON.stringify(data, null, 2)],
+        { type: 'application/json' }
+    );
+
+    const url = URL.createObjectURL(blob);
+
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = 'base64-output.json';
+    a.click();
+
+    URL.revokeObjectURL(url);
+};
+
+// PDF Export
+exportPdfBtn.onclick = () => {
+    if (!hasOutput()) return;
+
+    const { jsPDF } = window.jspdf;
+
+    const doc = new jsPDF();
+
+    doc.setFontSize(16);
+    doc.text('Base64 Converter Output', 10, 15);
+
+    doc.setFontSize(11);
+
+    const lines = doc.splitTextToSize(output.value, 180);
+doc.text(lines, 10, 30, {
+    maxWidth: 180
+});
+
+    doc.save('base64-output.pdf');
+};

--- a/tools/base64/base64.html
+++ b/tools/base64/base64.html
@@ -189,6 +189,11 @@
 
             <label>OUTPUT</label>
             <textarea id="output" readonly placeholder="Result will appear here..."></textarea>
+            <div class="btn-group">
+    <button id="exportTxtBtn">Export TXT</button>
+    <button id="exportJsonBtn">Export JSON</button>
+    <button id="exportPdfBtn">Export PDF</button>
+</div>
         </section>
     </main>
 
@@ -196,6 +201,7 @@
         <a href="../../index.html">← Back to Home</a>
     </footer>
 
-    <script src="base64-logic.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js"></script>
+<script src="base64-logic.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary

Added export functionality to the Base64 Converter, allowing users to export generated output in TXT, JSON, and PDF formats without storing any data persistently.

## Related Issue

Closes #314

## Changes

* Added Export TXT button to download the generated Base64 output as a `.txt` file.
* Added Export JSON button to export the input, output, and export timestamp as a `.json` file.
* Added Export PDF button using jsPDF to save the generated output as a `.pdf` file.
* Added validation to prevent exporting when no output is available.
* Export buttons are enabled only after a valid output is generated.
* No persistent storage (localStorage/sessionStorage) is used, following the project's privacy-first approach.

## Testing

* [x] Added/updated tests (Manual testing)
* [x] Tested locally (describe steps below)

## Testing Steps

1. Open the Base64 Converter tool.
2. Enter sample text (e.g., `hello`) and click **Encode**.
3. Verify the output is generated.
4. Click **Export TXT** and confirm the text file downloads.
5. Click **Export JSON** and confirm the JSON file downloads with the correct data.
6. Click **Export PDF** and confirm the PDF downloads successfully.
7. Modify the input and verify export buttons remain disabled until a new output is generated.

## Contributor Details

* Name: Gunjan Agrawal
* GitHub Username: @Gunjan10-droid
* Program: SSoC 2026

## Checklist before requesting a review

* [x] Code follows the project's conventions
* [x] No secrets or `.env` values are committed
* [x] I have performed a self-review of my code
* [ ] Documentation has been updated if needed
* [x] CI passes
* [x] Linked the related issue above