### PR TITLE
fix: improve readability by increasing font size on privacy policy page

### DIFF
--- a/privacy.html
+++ b/privacy.html
@@ -69,7 +69,7 @@ main {
 
 h2 {
     text-transform: uppercase;
-    font-size: 1.4rem;
+    font-size: 1.6rem;
     margin-bottom: 24px;
     border-bottom: 3px solid var(--border);
     display: inline-block;
@@ -80,6 +80,16 @@ p {
     max-width: 760px;
     margin-bottom: 24px;
     line-height: 1.75;
+    font-size: 1.1rem;
+}
+
+.feature {
+    padding: 26px;
+    border: 2px dashed var(--border);
+    border-radius: 12px;
+    background: var(--tag-bg);
+    font-size: 1.05rem;
+    line-height: 1.7;
 }
 
 /* FEATURE GRID */
@@ -111,6 +121,8 @@ ul {
 
 li {
     margin-bottom: 14px;
+    font-size: 1.1rem;
+    line-height: 1.8;
 }
 
 /* CTA */
@@ -141,7 +153,7 @@ li {
 }
 
 /* MOBILE */
-@media (max-width: 600px) {
+    @media (max-width: 600px) {
     h1 {
         font-size: 2.2rem;
     }
@@ -152,6 +164,16 @@ li {
 
     .card {
         padding: 32px;
+    }
+
+    p,
+    li,
+    .feature {
+        font-size: 1rem;
+    }
+
+    h2 {
+        font-size: 1.35rem;
     }
 }
 </style>


### PR DESCRIPTION
## Summary

Improved the readability of the Privacy Policy page by increasing the font size and adjusting typography while preserving the existing design and responsiveness.

## Related Issue

Closes #322

## Changes

* Increased paragraph font size for better readability.
* Increased list item font size and improved line height.
* Increased section heading (`h2`) font size for better visual hierarchy.
* Increased feature card text size.
* Added responsive typography adjustments for smaller screens.
* Preserved the existing layout, styling, and overall design consistency.

## Testing

* [ ] Added/updated tests
* [x] Tested locally (describe steps below)

## Testing Steps

1. Started the project locally using the development server.
2. Opened the Privacy Policy page and verified the updated typography.
3. Tested the page on desktop and mobile viewport sizes using browser developer tools to ensure responsiveness and consistent spacing.

## Contributor Details

* Name: Sargam Ghagre
* GitHub Username: @Sargam-Ghagre
* Program: SSoC26

## Checklist before requesting a review

* [x] Code follows the project's conventions
* [x] No secrets or `.env` values are committed
* [x] I have performed a self-review of my code
* [x] Documentation has been updated if needed
* [x] CI passes
* [x] Linked the related issue above
