### PR TITLE
fix: unreadable select options in dark mode in unit converter

### DIFF
--- a/tools/unit-converter/unit-converter.html
+++ b/tools/unit-converter/unit-converter.html
@@ -157,6 +157,17 @@
             background-repeat: no-repeat;
             background-position: right 8px center;
             background-size: 16px;
+            color-scheme: light;
+        }
+
+        body.dark-mode .input-group select,
+        .dark-mode .input-group select {
+            color-scheme: dark;
+        }
+
+        .input-group select option {
+            background: var(--bg);
+            color: var(--text);
         }
 
         #swapBtn {


### PR DESCRIPTION
## Summary

Fixes unreadable dropdown options in the Unit Converter when dark mode is enabled.

## Related Issue

Closes #331 

## Changes

* Added `color-scheme: light` / `color-scheme: dark` to `.input-group select` so the browser renders native dropdown popups (background, scrollbar, etc.) with the correct theme palette.
* Explicitly styled `.input-group select option` with `background: var(--bg)` and `color: var(--text)` as a fallback, since some browsers don't fully respect `color-scheme` for option lists.

## Testing

* [ ] Added/updated tests
* [x] Tested locally (describe steps below)

## Testing Steps

1. Open `tools/unit-converter/unit-converter.html` in the browser.
2. Click the "Dark Mode" toggle.
3. Click on the "From" and "To" unit dropdowns and confirm option text is clearly readable (no more white-on-white).
4. Toggle back to light mode and confirm dropdowns still render correctly there too.

## Contributor Details

* Name: Mehwish
* GitHub Username: MEHWISH310
* Program (SSoC / GSSoC / Hacktoberfest / Other): SSoC

## Checklist before requesting a review

* [x] Code follows the project's conventions
* [x] No secrets or `.env` values are committed
* [x] I have performed a self-review of my code
* [ ] Documentation has been updated if needed
* [ ] CI passes
* [x] Linked the related issue above

## Screenshot
<img width="1900" height="902" alt="image" src="https://github.com/user-attachments/assets/adb488ba-c2f0-4248-8d95-4cf856800284" />