### PR TITLE
Feature/copy tool link

### DIFF
--- a/index.html
+++ b/index.html
@@ -248,6 +248,88 @@
         border-color 0.25s ease;
     }
 
+    .tool-card {
+      position: relative;
+    }
+
+    .copy-link-btn {
+      position: absolute;
+      top: 10px;
+      right: 10px;
+
+      border: 2px solid var(--border);
+      background: var(--surface);
+      color: var(--text);
+
+      cursor: pointer;
+
+      border-radius: 8px;
+
+      padding: 4px 8px;
+
+      transition: all .2s ease;
+    }
+
+    .copy-link-btn:hover {
+      background: var(--text);
+      color: var(--bg);
+    }
+
+    /* ===========================
+   Copy Toast
+=========================== */
+
+.copy-toast {
+  position: fixed;
+  top: 20px;
+  right: 10px;
+
+  display: flex;
+  align-items: center;
+  gap: 12px;
+
+  min-width: 260px;
+
+  padding: 14px 18px;
+
+  background: #1f2937;
+  color: #fff;
+
+  border-left: 5px solid #22c55e;
+  border-radius: 12px;
+
+  box-shadow: 0 12px 30px rgba(0,0,0,.25);
+
+  z-index: 99999;
+
+  opacity: 0;
+  transform: translateX(120%);
+  transition:
+      transform .35s ease,
+      opacity .35s ease;
+}
+
+.copy-toast.show {
+  opacity: 1;
+  transform: translateX(0);
+}
+
+.copy-toast.hide {
+  opacity: 0;
+  transform: translateX(120%);
+}
+
+.copy-toast svg {
+  width: 22px;
+  height: 22px;
+  flex-shrink: 0;
+}
+
+.copy-toast-title {
+  font-weight: 700;
+  margin-bottom: 2px;
+}
+
     .tool-link:hover {
       transform: translateY(-5px);
 
@@ -1065,16 +1147,115 @@
       container.innerHTML = filtered
         .map(
           (t) => `
-      <a href="${t.path}" class="tool-link">
-        <div>${t.name}</div>
-        <div class="tool-tags">
-          ${t.tags.map(tag => `<span class="tag">${tag}</span>`).join("")}
-        </div>
-      </a>
-    `
+<div class="tool-card">
+
+<a href="${t.path}" class="tool-link">
+    <div>${t.name}</div>
+
+    <div class="tool-tags">
+        ${t.tags
+              .map(tag => `<span class="tag">${tag}</span>`)
+              .join("")}
+    </div>
+</a>
+
+<button
+    class="copy-link-btn"
+    onclick="copyToolLink(event, '${t.path}')"
+    title="Copy Link"
+>
+📋
+</button>
+
+</div>
+`
         )
         .join("");
     }
+
+   async function copyToolLink(event, path) {
+
+    event.preventDefault();
+    event.stopPropagation();
+
+    try {
+
+        await navigator.clipboard.writeText(
+            `${window.location.origin}/${path}`
+        );
+
+        showCopyToast();
+
+    } catch (err) {
+
+        console.error(err);
+
+    }
+
+}
+
+    function showCopyToast() {
+
+    const old = document.querySelector(".copy-toast");
+
+    if (old) old.remove();
+
+    const toast = document.createElement("div");
+
+    toast.className = "copy-toast";
+
+    toast.innerHTML = `
+
+    <svg
+    xmlns="http://www.w3.org/2000/svg"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="#22c55e"
+    stroke-width="2.5"
+    stroke-linecap="round"
+    stroke-linejoin="round">
+
+        <circle
+            cx="12"
+            cy="12"
+            r="10"
+            fill="rgba(34,197,94,.15)">
+        </circle>
+
+        <path
+            d="M8 12.5l2.5 2.5L16.5 9">
+        </path>
+
+    </svg>
+
+    <div>
+
+        <div class="copy-toast-title">
+            Link Copied!
+        </div>
+
+    </div>
+
+    `;
+
+    document.body.appendChild(toast);
+
+    requestAnimationFrame(() => {
+        toast.classList.add("show");
+    });
+
+    setTimeout(() => {
+
+        toast.classList.remove("show");
+        toast.classList.add("hide");
+
+        setTimeout(() => {
+            toast.remove();
+        }, 350);
+
+    }, 2200);
+
+}
 
     document.getElementById("toolSearch").oninput = renderTools;
 

--- a/index.html
+++ b/index.html
@@ -991,9 +991,9 @@
         tags: ["Dev", "DevOps"],
       },
       {
-          name: "Tool Health Checker",
-          path: "tools/health-checker/health-checker.html",
-          tags: ["Maintenance", "Utilities"],
+        name: "Tool Health Checker",
+        path: "tools/health-checker/health-checker.html",
+        tags: ["Maintenance", "Utilities"],
       },
     ];
 
@@ -1130,49 +1130,39 @@
     }
   </script>
   <script src="./theme.js"></script>
+
+  <script>
+    if ('serviceWorker' in navigator) {
+      window.addEventListener('load', async () => {
+        try {
+          const registration = await navigator.serviceWorker.register('./sw.js');
+
+          registration.addEventListener('updatefound', () => {
+            const newWorker = registration.installing;
+
+            if (!newWorker) return;
+
+            newWorker.addEventListener('statechange', () => {
+              if (
+                newWorker.state === 'installed' &&
+                navigator.serviceWorker.controller
+              ) {
+                const shouldRefresh = confirm(
+                  'A new version of Project Toolsuite is available. Refresh now?'
+                );
+
+                if (shouldRefresh) {
+                  window.location.reload();
+                }
+              }
+            });
+          });
+        } catch (error) {
+          console.error('Service Worker registration failed:', error);
+        }
+      });
+    }
+  </script>
 </body>
 
-  });
-}
-
-if (document.readyState === 'loading') {
-  document.addEventListener('DOMContentLoaded', initSpinner);
-} else {
-  initSpinner();
-}
-    </script>
-    <script src="./theme.js"></script>
-    <script>
-if ('serviceWorker' in navigator) {
-  window.addEventListener('load', async () => {
-    try {
-      const registration = await navigator.serviceWorker.register('./sw.js');
-
-      registration.addEventListener('updatefound', () => {
-        const newWorker = registration.installing;
-
-        if (!newWorker) return;
-
-        newWorker.addEventListener('statechange', () => {
-          if (
-            newWorker.state === 'installed' &&
-            navigator.serviceWorker.controller
-          ) {
-            const shouldRefresh = confirm(
-              'A new version of Project Toolsuite is available. Refresh now?'
-            );
-
-            if (shouldRefresh) {
-              window.location.reload();
-            }
-          }
-        });
-      });
-    } catch (error) {
-      console.error('Service Worker registration failed:', error);
-    }
-  });
-}
-</script>
-  </body>
 </html>


### PR DESCRIPTION
## Summary

This PR adds a **Copy Link** button to every tool card, allowing users to quickly copy a tool's direct URL without manually copying it from the browser address bar.

## Closes #286

<!-- Example: Closes #123 -->

## Changes

* Added a copy link button to each tool card.
* Correct absolute URL is copied to the clipboard.
* Added a success toast positioned at the top-right corner.
* Added smooth slide-in and fade-out animations.
* Ensured only one toast appears even when navigating repeatedly.
* Prevented duplicate loading notifications caused by multiple event listeners.
* Kept the loading spinner functionality unchanged.

## Testing

* [ ] Added/updated tests
* [x] Tested locally (describe steps below)

## Testing Steps

1. Open the Project Toolsuite homepage.
2. Click any tool card.
3. Verify that the loading spinner appears.
4. Wait for the tool to load.
5. Confirm a success toast appears in the top-right corner.
6. Verify the toast contains the custom SVG success icon.
7. Ensure the toast automatically disappears after a few seconds.
8. Navigate between multiple tools and confirm duplicate toasts do not appear.

## Screenshots

### Before

<img width="722" height="547" alt="image" src="https://github.com/user-attachments/assets/3484bcd3-6f37-419a-a822-971b89008cf0" />

### After

<img width="1325" height="552" alt="image" src="https://github.com/user-attachments/assets/2c6d27e9-6207-438d-a50e-5940d5ee0f20" />

## Contributor Details

* **Name:** Lovepreet Kaur
* **GitHub Username:** love25-codes
* **Program:** SSoC 2026

## Checklist before requesting a review

* [x] Code follows the project's conventions
* [x] No secrets or `.env` values are committed
* [x] I have performed a self-review of my code
* [ ] Documentation has been updated if needed
* [ ] CI passes
* [x] Linked the related issue above