### PR TITLE
fix: align PWA manifest theme_color with dark theme palette

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -4,7 +4,7 @@
   "start_url": "./index.html",
   "display": "standalone",
   "background_color": "#1b1a1a",
-  "theme_color": "#ffffff",
+  "theme_color": "#0f172a",
   "description": "A collection of fast, minimal, privacy-first tools designed to get work done without friction.",
   "icons": [
   {


### PR DESCRIPTION
## Summary

Align the PWA manifest `theme_color` with the application's dark theme palette.

## Changes

* Updated `theme_color` in `manifest.json`
* Changed value from `#ffffff` to `#0f172a`

## Rationale

The application uses a dark theme, but the manifest specified a white theme color. On platforms that use the manifest theme color for browser chrome, splash screens, or installed PWA UI, this could result in visual inconsistencies during launch.

Updating the manifest to use the dark theme color improves visual continuity and better reflects the application's design system.

## Testing

* Verified `manifest.json` contains the updated `theme_color`
* Confirmed the manifest remains valid JSON
* Confirmed existing `background_color` remains unchanged

closes #335