### PR TITLE
feat: geometric properties added

### DIFF
--- a/tools/vector-studio/studio_vector.js
+++ b/tools/vector-studio/studio_vector.js
@@ -41,8 +41,8 @@ isSelected(shape) {
 clearSelection() {
     this.selectedShapes = [];
     this.selection = null;
+    this.updatePropsUI();
 }
-
 selectSingle(shape) {
     this.selectedShapes = [shape];
     this.selection = shape;
@@ -82,6 +82,84 @@ toggleSelection(shape) {
         }
         return inside;
     }
+
+    createGeometryInput(label, id, value, type = 'number') {
+    return `
+        <div class="prop-group">
+            <label class="prop-label" for="${id}">${label}</label>
+            <input
+                type="${type}"
+                id="${id}"
+                class="prop-input"
+                value="${value ?? ''}"
+            >
+        </div>
+    `;
+}
+
+
+attachGeometryListeners() {
+    const bindInput = (id, callback) => {
+        const input = document.getElementById(id);
+
+        if (!input) return;
+
+       input.addEventListener('change', () => {
+    if (this.selectedShapes.length !== 1) return;
+
+    this.saveState();
+
+    callback(
+        this.selectedShapes[0],
+        input.value
+    );
+
+    this.saveToLocalStorage();
+
+    this.updatePropsUI();
+});
+    };
+
+    bindInput('geometryX', (shape, value) => {
+        shape.x = parseFloat(value) || 0;
+    });
+
+    bindInput('geometryY', (shape, value) => {
+        shape.y = parseFloat(value) || 0;
+    });
+
+    bindInput('geometryWidth', (shape, value) => {
+        shape.w = parseFloat(value) || 0;
+    });
+
+    bindInput('geometryHeight', (shape, value) => {
+        shape.h = parseFloat(value) || 0;
+    });
+
+    bindInput('geometryRadius', (shape, value) => {
+        shape.r = Math.max(0, parseFloat(value) || 0);
+    });
+
+    bindInput('geometryX1', (shape, value) => {
+        shape.x = parseFloat(value) || 0;
+    });
+
+    bindInput('geometryY1', (shape, value) => {
+        shape.y = parseFloat(value) || 0;
+    });
+
+    bindInput('geometryX2', (shape, value) => {
+        shape.ex = parseFloat(value) || 0;
+    });
+
+    bindInput('geometryY2', (shape, value) => {
+        shape.ey = parseFloat(value) || 0;
+    });
+
+    bindInput('geometryText', (shape, value) => {
+        shape.text = value;
+    });
+}
 
     distToSegment(p, v, w) {
         const l2 = (v.x - w.x) ** 2 + (v.y - w.y) ** 2;
@@ -492,11 +570,11 @@ this.selectedShapes.forEach(shape => {
 
     // --- API UTILS ---
 
-    setTool(name) {
-        this.tool = name;
-        this.selection = null;
-        this.updateToolbar();
-    }
+ setTool(name) {
+    this.tool = name;
+    this.clearSelection();
+    this.updateToolbar();
+}
 
     updateToolbar() {
         document.querySelectorAll('.tool').forEach(el => el.classList.remove('active'));
@@ -505,15 +583,27 @@ this.selectedShapes.forEach(shape => {
         this.canvas.style.cursor = this.tool === 'select' ? 'default' : 'crosshair';
     }
 
-   updatePropsUI() {
+  updatePropsUI() {
+    const geometryPanel = document.getElementById('geometry-properties');
 
-    if (this.selectedShapes.length === 0) return;
+    if (this.selectedShapes.length === 0) {
+        geometryPanel.innerHTML = '';
+        return;
+    }
 
     const first = this.selectedShapes[0];
 
-    const sameFill = this.selectedShapes.every(s => s.fill === first.fill);
-    const sameStroke = this.selectedShapes.every(s => s.stroke === first.stroke);
-    const sameWidth = this.selectedShapes.every(s => s.width === first.width);
+    const sameFill = this.selectedShapes.every(
+        s => s.fill === first.fill
+    );
+
+    const sameStroke = this.selectedShapes.every(
+        s => s.stroke === first.stroke
+    );
+
+    const sameWidth = this.selectedShapes.every(
+        s => s.width === first.width
+    );
 
     document.getElementById('fillColor').value =
         sameFill ? first.fill : '#000000';
@@ -524,6 +614,117 @@ this.selectedShapes.forEach(shape => {
     document.getElementById('strokeWidth').value =
         sameWidth ? first.width : '';
 
+    // Geometry properties are only shown for a single selected shape.
+    if (this.selectedShapes.length !== 1) {
+        geometryPanel.innerHTML = `
+            <div class="prop-label">
+                Geometry editing is available for one selected shape at a time.
+            </div>
+        `;
+        return;
+    }
+
+    let html = '';
+
+    if (
+        ['rect', 'oval', 'diamond', 'parallelogram']
+            .includes(first.type)
+    ) {
+        html += this.createGeometryInput(
+            'X',
+            'geometryX',
+            first.x
+        );
+
+        html += this.createGeometryInput(
+            'Y',
+            'geometryY',
+            first.y
+        );
+
+        html += this.createGeometryInput(
+            'Width',
+            'geometryWidth',
+            first.w
+        );
+
+        html += this.createGeometryInput(
+            'Height',
+            'geometryHeight',
+            first.h
+        );
+    }
+
+    else if (first.type === 'circle') {
+        html += this.createGeometryInput(
+            'X',
+            'geometryX',
+            first.x
+        );
+
+        html += this.createGeometryInput(
+            'Y',
+            'geometryY',
+            first.y
+        );
+
+        html += this.createGeometryInput(
+            'Radius',
+            'geometryRadius',
+            first.r
+        );
+    }
+
+    else if (['line', 'arrow'].includes(first.type)) {
+        html += this.createGeometryInput(
+            'X1',
+            'geometryX1',
+            first.x
+        );
+
+        html += this.createGeometryInput(
+            'Y1',
+            'geometryY1',
+            first.y
+        );
+
+        html += this.createGeometryInput(
+            'X2',
+            'geometryX2',
+            first.ex
+        );
+
+        html += this.createGeometryInput(
+            'Y2',
+            'geometryY2',
+            first.ey
+        );
+    }
+
+    else if (first.type === 'text') {
+        html += this.createGeometryInput(
+            'X',
+            'geometryX',
+            first.x
+        );
+
+        html += this.createGeometryInput(
+            'Y',
+            'geometryY',
+            first.y
+        );
+
+        html += this.createGeometryInput(
+            'Text',
+            'geometryText',
+            first.text,
+            'text'
+        );
+    }
+
+    geometryPanel.innerHTML = html;
+
+    this.attachGeometryListeners();
 }
 
     saveState(state = null) {

--- a/tools/vector-studio/vector_studio.html
+++ b/tools/vector-studio/vector_studio.html
@@ -258,6 +258,21 @@
             font-size: 30px;
             color: var(--accent);
         }
+
+        #geometry-properties {
+    display: flex;
+    flex-direction: column;
+    gap: 15px;
+}
+
+
+.geometry-info {
+    font-size: 0.7rem;
+    color: var(--muted);
+    line-height: 1.5;
+}
+
+
     </style>
         <link rel="stylesheet" href="../../theme.css">
 </head>
@@ -276,7 +291,6 @@
                 </span>
                 <h1>Vector Studio</h1>
             </div>
-        </div>
         <div style="display: flex; gap: 10px; align-items: center;">
             <button class="btn" onclick="app.export('png')">EXPORT PNG</button>
             <button class="btn" onclick="app.export('svg')">EXPORT SVG</button>
@@ -336,6 +350,9 @@
                 <label class="prop-label">Stroke Width</label>
                 <input type="number" id="strokeWidth" class="prop-input" value="2" min="0" max="20">
             </div>
+
+            <div id="geometry-properties"></div>
+
             <hr style="width:100%; border:1px solid #333">
             <div class="prop-group">
                 <label class="prop-label">Snap Grid</label>


### PR DESCRIPTION
## Summary

Added a geometric properties panel to Vector Studio that allows users to view and edit the precise geometric properties of selected shapes.

## Closes #358 

<!-- Example: Closes #123 -->

## Changes

* Added a dynamic geometry properties panel for selected shapes.
* Added editable `X` and `Y` position properties for geometric shapes.
* Added editable `Width` and `Height` properties for:
  * Rectangles
  * Ovals
  * Diamonds
  * Parallelograms
* Added editable `X`, `Y`, and `Radius` properties for circles.
* Added editable start and end coordinates (`X1`, `Y1`, `X2`, `Y2`) for lines and arrows.
* Added editable `X`, `Y`, and text content properties for text elements.
* Added support for updating shapes directly through the properties panel.
* Changes made through the geometry properties panel are automatically reflected on the canvas.
* Added undo/redo support for geometry property changes.
* Added automatic localStorage saving after geometry properties are modified.
* Geometry editing is restricted to one selected shape at a time to avoid ambiguous property editing.
* Added support for multi-selection while keeping geometry editing available for individual shapes.

## Testing

* [ ] Added/updated tests
* [x] Tested locally (describe steps below)

## Testing Steps

1. Open Vector Studio locally.
2. Create a rectangle, oval, diamond, or parallelogram.
3. Select the shape and verify that its `X`, `Y`, `Width`, and `Height` properties are displayed.
4. Modify any of the geometric values and verify that the shape updates correctly on the canvas.
5. Create a circle and verify that `X`, `Y`, and `Radius` properties are available.
6. Create a line or arrow and verify that its start and end coordinates can be edited.
7. Create a text element and verify that its position and text content can be edited.
8. Verify that geometry changes can be undone and redone using `Ctrl + Z` and `Ctrl + Y`.
9. Refresh the page and verify that the updated shapes are restored from localStorage.
10. Select multiple shapes and verify that geometry editing displays a message indicating that only one shape can be edited at a time.

## Screenshots
### Before:
<img width="1897" height="832" alt="image" src="https://github.com/user-attachments/assets/a4e68869-e9b0-4e06-b100-c942fc7c4754" />


### After:
<img width="1916" height="930" alt="image" src="https://github.com/user-attachments/assets/2d4b5624-6003-4199-9dba-2b0751c4fcc3" />
<img width="1913" height="786" alt="image" src="https://github.com/user-attachments/assets/269aacb8-7ce5-41e1-84ac-98543a51deb1" />


## Contributor Details

* Name: Lovepreet Kaur
* GitHub Username: @love25-codes 
* Program: SSoC26

## Checklist before requesting a review

* [x] Code follows the project's conventions
* [x] No secrets or `.env` values are committed
* [x] I have performed a self-review of my code
* [ ] Documentation has been updated if needed
* [ ] CI passes
* [ ] Linked the related issue above