### PR TITLE
fix: no selection alert on delete shape

### DIFF
--- a/tools/vector-studio/studio_vector.js
+++ b/tools/vector-studio/studio_vector.js
@@ -591,8 +591,11 @@ this.selectedShapes.forEach(shape => {
         console.log('localStorage cleared');
     }
 
-   deleteSelected() {
-    if (this.selectedShapes.length === 0) return;
+  deleteSelected() {
+    if (this.selectedShapes.length == 0) {
+        alert("No shape selected. Please select a shape to delete.");
+        return;
+    }
 
     this.saveState();
 


### PR DESCRIPTION
## Summary

Adds user feedback when attempting to delete a shape without selecting one.

## Closes #360 

## Changes

* Added an alert message when the delete action is triggered without any selected shape.
* Preserved the existing deletion behavior for one or more selected shapes.

## Screenshots
### After:
<img width="1912" height="792" alt="image" src="https://github.com/user-attachments/assets/0588a2df-50dd-4691-b40f-169c2b1e5320" />


## Testing

* [x] Verified that an alert is shown when no shape is selected.
* [x] Verified that a selected shape can still be deleted.
* [x] Verified that multiple selected shapes can still be deleted.
* [x] Verified Delete and Backspace keyboard actions.