### PR TITLE
fix: prevent zero size geometry

### DIFF
--- a/tools/vector-studio/studio_vector.js
+++ b/tools/vector-studio/studio_vector.js
@@ -104,20 +104,30 @@ attachGeometryListeners() {
 
         if (!input) return;
 
-       input.addEventListener('change', () => {
-    if (this.selectedShapes.length !== 1) return;
+        input.addEventListener('change', () => {
+            if (this.selectedShapes.length !== 1) return;
 
-    this.saveState();
+            this.saveState();
 
-    callback(
-        this.selectedShapes[0],
-        input.value
-    );
+            callback(
+                this.selectedShapes[0],
+                input.value
+            );
 
-    this.saveToLocalStorage();
+            this.saveToLocalStorage();
 
-    this.updatePropsUI();
-});
+            this.updatePropsUI();
+        });
+    };
+
+    const getMinimumGeometryValue = (value) => {
+        const parsedValue = parseFloat(value);
+
+        if (!Number.isFinite(parsedValue)) {
+            return 1;
+        }
+
+        return Math.max(1, parsedValue);
     };
 
     bindInput('geometryX', (shape, value) => {
@@ -129,15 +139,15 @@ attachGeometryListeners() {
     });
 
     bindInput('geometryWidth', (shape, value) => {
-        shape.w = parseFloat(value) || 0;
+        shape.w = getMinimumGeometryValue(value);
     });
 
     bindInput('geometryHeight', (shape, value) => {
-        shape.h = parseFloat(value) || 0;
+        shape.h = getMinimumGeometryValue(value);
     });
 
     bindInput('geometryRadius', (shape, value) => {
-        shape.r = Math.max(0, parseFloat(value) || 0);
+        shape.r = getMinimumGeometryValue(value);
     });
 
     bindInput('geometryX1', (shape, value) => {


### PR DESCRIPTION
## Summary

Prevent zero-size and invalid geometry values from being assigned to shapes through the Vector Studio properties panel.

## Closes #362 

<!-- Example: Closes #123 -->

## Changes

<!-- Bullet list of what changed and why. -->

* Added minimum geometry validation to ensure width, height, and radius values cannot be less than `1`.
* Added handling for invalid, empty, negative, and zero numeric inputs by correcting them to `1`.
* Applied validation to rectangle, oval, diamond, and parallelogram width and height properties.
* Applied validation to circle radius properties.
* Preserved existing geometry editing functionality for valid values.
* Ensured corrected geometry values continue to be persisted through the existing `localStorage` mechanism.

## Testing

* [ ] Added/updated tests
* [x] Tested locally (describe steps below)

## Testing Steps

1. Created and selected rectangles, ovals, diamonds, parallelograms, and circles in Vector Studio.
2. Edited geometry properties using valid values, `0`, negative values, empty values, and invalid text input.
3. Verified that width, height, and radius values are automatically corrected to a minimum of `1`.
4. Verified that valid positive values continue to work correctly.
5. Refreshed the application and confirmed that corrected geometry values were persisted through `localStorage`.
6. Verified that shapes remain visible and usable on the canvas after invalid geometry input.

## Contributor Details

* Name: Lovepreet Kaur
* GitHub Username: @love25-codes 
* Program (SSoC / GSSoC / Hacktoberfest / Other): SSoC26

## Checklist before requesting a review

* [x] Code follows the project's conventions
* [x] No secrets or `.env` values are committed
* [x] I have performed a self-review of my code
* [ ] Documentation has been updated if needed
* [ ] CI passes
* [x] Linked the related issue above