### PR TITLE
feat: duplicate button added

### DIFF
--- a/tools/vector-studio/studio_vector.js
+++ b/tools/vector-studio/studio_vector.js
@@ -64,6 +64,42 @@ toggleSelection(shape) {
             : null;
 }
 
+duplicateSelected() {
+    if (this.selectedShapes.length === 0) {
+        return;
+    }
+
+    this.saveState();
+
+    const offset = 20;
+
+    const duplicatedShapes = this.selectedShapes.map(shape => {
+        const duplicate = JSON.parse(
+            JSON.stringify(shape)
+        );
+
+        duplicate.x += offset;
+        duplicate.y += offset;
+
+        if (['line', 'arrow'].includes(duplicate.type)) {
+            duplicate.ex += offset;
+            duplicate.ey += offset;
+        }
+
+        return duplicate;
+    });
+
+    this.shapes.push(...duplicatedShapes);
+
+    this.selectedShapes = duplicatedShapes;
+
+    this.selection =
+        duplicatedShapes[duplicatedShapes.length - 1];
+
+    this.saveToLocalStorage();
+    this.updatePropsUI();
+}
+
     // --- MATH UTILS ---
 
     snap(val) {

--- a/tools/vector-studio/vector_studio.html
+++ b/tools/vector-studio/vector_studio.html
@@ -360,6 +360,14 @@
             </div>
             <button class="btn" onclick="app.deleteSelected()"
                 style="margin-top:20px; border-color:#ff4444; color:#ff4444;">DELETE SHAPE</button>
+
+                <button class="btn"
+    id="duplicateButton"
+    style="margin-top:3px; border-color:#ff4444; color:#ff4444;"
+    onclick="app.duplicateSelected()"
+>
+    DUPLICATE
+</button>
         </aside>
     </div>
 


### PR DESCRIPTION
## Summary

Add a Duplicate button that allows users to duplicate one or more selected shapes while preserving their geometry and relative positioning.

## Closes #364 

<!-- Example: Closes #123 -->

## Changes

<!-- Bullet list of what changed and why. -->

* Added a visible `Duplicate` button to the editor UI.
* Added support for duplicating a single selected shape.
* Added support for duplicating multiple selected shapes at once.
* Created independent copies of selected shapes using deep cloning.
* Offset duplicated shapes by `20px` horizontally and vertically to make them visually distinguishable from the originals.
* Preserved the relative positioning between multiple duplicated shapes.
* Added special handling for lines and arrows to offset both endpoints correctly.
* Automatically selected the newly duplicated shapes after duplication.
* Added undo support by saving the canvas state before duplication.
* Persisted duplicated shapes using the existing `localStorage` mechanism.
* Clicking the Duplicate button without any selected shapes does not create duplicates.

## Testing

* [ ] Added/updated tests
* [x] Tested locally (describe steps below)

## Testing Steps

1. Created and selected a single shape, then clicked the `Duplicate` button and verified that an independent copy was created with a `20px` offset.
2. Selected multiple shapes and clicked `Duplicate`, verifying that all selected shapes were duplicated while preserving their relative positions.
3. Tested duplication with rectangles, circles, ovals, diamonds, parallelograms, lines, arrows, and text shapes.
4. Verified that lines and arrows preserved their geometry and that both endpoints were offset correctly.
5. Verified that the newly duplicated shapes became the active selection.
6. Clicked `Duplicate` with no shape selected and verified that no new shapes were created.
7. Used the existing undo functionality after duplication and verified that the duplicated shapes were removed.
8. Refreshed the application and verified that duplicated shapes persisted through `localStorage`.

## Screenshots:
### After:
<img width="1913" height="793" alt="image" src="https://github.com/user-attachments/assets/f0dbcbbf-3b4c-434a-9994-e6bf6dcd3264" />


## Contributor Details

* Name: Lovepreet Kaur
* GitHub Username: @love25-codes 
* Program (SSoC / GSSoC / Hacktoberfest / Other): SSoC26

## Checklist before requesting a review

* [x] Code follows the project's conventions
* [x] No secrets or `.env` values are committed
* [x] I have performed a self-review of my code
* [ ] Documentation has been updated if needed
* [ ] CI passes
* [x] Linked the related issue above