### PR TITLE
feat: reset-selected-shape implemented

### DIFF
--- a/tools/vector-studio/studio_vector.js
+++ b/tools/vector-studio/studio_vector.js
@@ -64,6 +64,47 @@ toggleSelection(shape) {
             : null;
 }
 
+resetGeometry() {
+    if (this.selectedShapes.length !== 1) {
+        return;
+    }
+
+    const shape = this.selectedShapes[0];
+
+    this.saveState();
+
+    if (
+        ['rect', 'oval', 'diamond', 'parallelogram']
+            .includes(shape.type)
+    ) {
+        shape.x = 0;
+        shape.y = 0;
+        shape.w = 100;
+        shape.h = 100;
+    }
+
+    else if (shape.type === 'circle') {
+        shape.x = 0;
+        shape.y = 0;
+        shape.r = 50;
+    }
+
+    else if (['line', 'arrow'].includes(shape.type)) {
+        shape.x = 0;
+        shape.y = 0;
+        shape.ex = 100;
+        shape.ey = 100;
+    }
+
+    else if (shape.type === 'text') {
+        shape.x = 0;
+        shape.y = 0;
+    }
+
+    this.saveToLocalStorage();
+    this.updatePropsUI();
+}
+
     // --- MATH UTILS ---
 
     snap(val) {
@@ -731,6 +772,18 @@ this.selectedShapes.forEach(shape => {
             'text'
         );
     }
+
+    html += `
+    <button
+        type="button"
+        class="reset-geometry-button btn"
+         style="margin-top:20px; border-color:#44ffca; color:#44ffca;"
+        onclick="app.resetGeometry()"
+    >
+        Reset Geometry
+    </button>
+`;
+
 
     geometryPanel.innerHTML = html;
 


### PR DESCRIPTION
## Summary

Add a `Reset Geometry` button that restores the selected shape's geometry to predefined default values.

## Related Issue

Closes #366 

<!-- Example: Closes #123 -->

## Changes

<!-- Bullet list of what changed and why. -->

* Added a visible `Reset Geometry` button for single selected shapes.
* Added type-specific default geometry values for rectangles, ovals, diamonds, and parallelograms.
* Added default geometry reset support for circles with a radius of `50`.
* Added default endpoint reset support for lines and arrows.
* Added position reset support for text shapes while preserving the existing text content.
* Ensured only geometry properties are reset without modifying fill, stroke, or stroke width.
* Added undo support by saving the current state before resetting geometry.
* Persisted reset geometry changes to `localStorage`.
* Updated the geometry properties UI to display the reset values immediately after the operation.
* Prevented reset actions when no shape or multiple shapes are selected.

## Testing

* [ ] Added/updated tests
* [x] Tested locally (describe steps below)

## Testing Steps

1. Selected a rectangle, changed its geometry values, clicked `Reset Geometry`, and verified that X and Y reset to `0` while width and height reset to `100`.
2. Tested the reset operation with ovals, diamonds, and parallelograms.
3. Selected a circle and verified that its position reset to `0, 0` and its radius reset to `50`.
4. Tested lines and arrows and verified that their endpoints reset to `(0, 0)` and `(100, 100)`.
5. Tested text shapes and verified that their position reset while the text content remained unchanged.
6. Verified that fill color, stroke color, and stroke width were preserved after resetting geometry.
7. Used the existing Undo functionality after resetting geometry and verified that the previous geometry was restored.
8. Refreshed the application and verified that the reset geometry persisted through `localStorage`.
9. Verified that the Reset Geometry button is only available when exactly one shape is selected.

## Screenshots:
### After:
<img width="1912" height="857" alt="image" src="https://github.com/user-attachments/assets/6dcb79e9-70d4-49ff-af9c-56026186c501" />


## Contributor Details

* Name: Lovepreet Kaur
* GitHub Username: @love25-codes 
* Program (SSoC / GSSoC / Hacktoberfest / Other): SSoC26

## Checklist before requesting a review

* [x] Code follows the project's conventions
* [x] No secrets or `.env` values are committed
* [x] I have performed a self-review of my code
* [ ] Documentation has been updated if needed
* [ ] CI passes
* [x] Linked the related issue above