### PR TITLE
fix/ no selection alert on duplicate shape

### DIFF
--- a/tools/vector-studio/studio_vector.js
+++ b/tools/vector-studio/studio_vector.js
@@ -66,6 +66,7 @@ toggleSelection(shape) {
 
 duplicateSelected() {
     if (this.selectedShapes.length === 0) {
+        alert("No shape selected. Please select a shape to duplicate.");
         return;
     }
 


### PR DESCRIPTION
## Summary

Adds user feedback when attempting to duplicate a shape without selecting one.

## Closes #368 

## Changes

* Added an alert message when the duplicate action is triggered without any selected shape.
* Preserved the existing duplication behavior for one or more selected shapes.

## Screenshots
### After:
<img width="1911" height="800" alt="image" src="https://github.com/user-attachments/assets/8b8d966f-f727-4d95-92fc-5e5e85bd3b00" />


## Testing

* [x] Verified that an alert is shown when no shape is selected.
* [x] Verified that a selected shape can still be duplicated.
* [x] Verified that multiple selected shapes can still be duplicated.