### PR TITLE
Add back to top button

### DIFF
--- a/index.html
+++ b/index.html
@@ -304,6 +304,47 @@
       color: var(--bg);
     }
 
+    #backToTopBtn {
+  position: fixed;
+  bottom: 30px;
+  right: 30px;
+  width: 48px;
+  height: 48px;
+  border: 3px solid var(--border);
+  border-radius: 50%;
+  background: var(--text);
+  color: var(--bg);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  opacity: 0;
+  visibility: hidden;
+  transform: translateY(10px);
+  transition: opacity 0.25s ease, transform 0.25s ease, visibility 0.25s ease;
+  z-index: 999;
+}
+
+#backToTopBtn.show {
+  opacity: 1;
+  visibility: visible;
+  transform: translateY(0);
+}
+
+#backToTopBtn:hover {
+  transform: translate(-2px, -2px);
+  box-shadow: 2px 2px 0px var(--border);
+}
+
+@media (max-width: 480px) {
+  #backToTopBtn {
+    width: 42px;
+    height: 42px;
+    bottom: 20px;
+    right: 20px;
+  }
+}
+
     /* ===========================
    Copy Toast
 =========================== */
@@ -829,6 +870,12 @@
         </div>
       </aside>
     </div>
+    <button id="backToTopBtn" aria-label="Back to top" title="Back to top">
+  <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
+    <line x1="12" y1="19" x2="12" y2="5"></line>
+    <polyline points="5 12 12 5 19 12"></polyline>
+  </svg>
+</button>
 
     <footer>
       <p>© 2026 PROJECT TOOLSUITE — SIMPLE. FAST. FREE.</p>
@@ -1419,6 +1466,21 @@ document
     }
   });
 }
+</script>
+<script>
+  const backToTopBtn = document.getElementById("backToTopBtn");
+
+window.addEventListener("scroll", () => {
+  if (window.scrollY > 300) {
+    backToTopBtn.classList.add("show");
+  } else {
+    backToTopBtn.classList.remove("show");
+  }
+});
+
+backToTopBtn.addEventListener("click", () => {
+  window.scrollTo({ top: 0, behavior: "smooth" });
+});
 </script>
 
 </body>


### PR DESCRIPTION
## Summary
Added a "Back to Top" button that appears on scroll and smoothly scrolls the user back to the top of the page.

## Related Issue
Closes #354

## Changes
* Added a fixed-position circular "Back to Top" button in `index.html`, styled using existing `theme.css` variables (`--bg`, `--text`, `--border`) to match dark/light mode.
* Button is hidden by default and fades in once the user scrolls past 300px.
* Clicking the button triggers a smooth scroll to the top of the page using `window.scrollTo({ top: 0, behavior: "smooth" })`.
* Added responsive sizing for smaller screens (max-width: 480px).

## Testing
* [x] Tested locally

## Testing Steps
1. Opened `index.html` directly in the browser.
2. Scrolled down the page and confirmed the button fades in after ~300px of scroll.
3. Clicked the button and confirmed smooth scroll back to top; also toggled dark/light mode to confirm the button styling adapts correctly.

## Screenshot
<img width="1918" height="906" alt="image" src="https://github.com/user-attachments/assets/f3352ee7-7b6a-4f13-9176-997ef82776c5" />

## Contributor Details
* Name: Mehwish
* GitHub Username: MEHWISH310
* Program (SSoC / GSSoC / Hacktoberfest / Other): SSoC

## Checklist before requesting a review
* [x] Code follows the project's conventions
* [x] No secrets or `.env` values are committed
* [x] I have performed a self-review of my code
* [ ] Documentation has been updated if needed
* [ ] CI passes
* [x] Linked the related issue above