### PR TITLE
fix/ side panel made scrollable

### DIFF
--- a/tools/vector-studio/vector_studio.html
+++ b/tools/vector-studio/vector_studio.html
@@ -127,11 +127,12 @@
         }
 
         /* WORKSPACE */
-        .workspace {
-            flex: 1;
-            display: flex;
-            position: relative;
-        }
+      .workspace {
+    flex: 1;
+    min-height: 0;
+    display: flex;
+    position: relative;
+}
 
         /* TOOLBAR (LEFT) */
         .toolbar {
@@ -182,16 +183,20 @@
         }
 
         /* PROPERTIES PANEL (RIGHT) */
-        .properties {
-            width: 250px;
-            background: var(--panel);
-            border-left: 2px solid var(--border);
-            padding: 20px;
-            display: flex;
-            flex-direction: column;
-            gap: 15px;
-            z-index: 20;
-        }
+     .properties {
+    width: 250px;
+    height: 100%;
+    min-height: 0;
+    background: var(--panel);
+    border-left: 2px solid var(--border);
+    padding: 20px;
+    display: flex;
+    flex-direction: column;
+    gap: 15px;
+    z-index: 20;
+    overflow-y: auto;
+    overflow-x: hidden;
+}
 
         .prop-group {
             display: flex;


### PR DESCRIPTION
## Summary

Make the Vector Studio properties side panel vertically scrollable so that all properties remain accessible when the panel contains more content than the available viewport height.

## Related Issue

Closes #371 

<!-- Example: Closes #123 -->

## Changes

<!-- Bullet list of what changed and why. -->

* Added vertical scrolling to the properties side panel using `overflow-y: auto`.
* Set the properties panel to use the available workspace height.
* Added `min-height: 0` to the flex layout to allow the panel to shrink correctly and scroll within the viewport.
* Prevented unnecessary horizontal scrolling with `overflow-x: hidden`.
* Ensured all properties and bottom controls remain accessible when the panel content exceeds the available height.

## Testing

<!-- How did you verify this works? -->

* [ ] Added/updated tests
* [x] Tested locally (described below)

## Testing Steps

1. Open Vector Studio and create or select a shape with multiple geometry properties.
2. Resize the browser window or add enough properties so that the properties panel content exceeds the available viewport height.
3. Verify that the right-side properties panel displays a vertical scrollbar and that all properties and bottom controls, including `DELETE SHAPE` and `DUPLICATE`, can be accessed by scrolling.
4. Verify that the canvas and left toolbar continue to work as expected.

## Contributor Details

* Name: Lovepreet Kaur
* GitHub Username: @love25-codes 
* Program (SSoC / GSSoC / Hacktoberfest / Other): SSoC

## Checklist before requesting a review

* [x] Code follows the project's conventions
* [x] No secrets or `.env` values are committed
* [x] I have performed a self-review of my code
* [x] Documentation has been updated if needed
* [ ] CI passes
* [x] Linked the related issue above