### PR TITLE
Fix: Timezone Converter now respects the From Timezone selection

### DIFF
--- a/tools/world-time/world-time.js
+++ b/tools/world-time/world-time.js
@@ -656,72 +656,48 @@ document.addEventListener(
 
 
     function convertTimezone(){
-
-
-    const date =
-    document.getElementById("convertDate").value;
-
-
-
-    const time =
-    document.getElementById("convertTime").value;
-
-
-
-    const from =
-    document.getElementById("fromZone").value;
-
-
-
-    const to =
-    document.getElementById("toZone").value;
-
-
+    const date = document.getElementById("convertDate").value;
+    const time = document.getElementById("convertTime").value;
+    const from = document.getElementById("fromZone").value;
+    const to = document.getElementById("toZone").value;
 
     if(!date || !time){
-
         alert("Please select date and time");
-
         return;
-
     }
 
+    // Treat input as naive wall-clock, first as if it were UTC
+    const naiveUTC = new Date(`${date}T${time}:00Z`);
 
+    // Find what that UTC instant reads as in `from` zone
+    const fromZoneParts = new Intl.DateTimeFormat("en-US", {
+        timeZone: from,
+        year: "numeric", month: "2-digit", day: "2-digit",
+        hour: "2-digit", minute: "2-digit", second: "2-digit",
+        hourCycle: "h23"
+    }).formatToParts(naiveUTC);
 
-    const dateTime =
-    `${date}T${time}:00`;
+    const get = (type) => fromZoneParts.find(p => p.type === type).value;
+    const asIfLocal = new Date(Date.UTC(
+        get("year"), get("month") - 1, get("day"),
+        get("hour"), get("minute"), get("second")
+    ));
 
-
-
-    const sourceDate =
-    new Date(
-        dateTime
-    );
-
-
+    const offsetMs = naiveUTC.getTime() - asIfLocal.getTime();
+    const sourceDate = new Date(naiveUTC.getTime() + offsetMs);
 
     const formatted =
     new Intl.DateTimeFormat(
         "en-US",
         {
-
         timeZone:to,
-
         dateStyle:"full",
-
         timeStyle:"medium"
-
         }
-
     ).format(sourceDate);
-
-
-
     document.getElementById(
         "conversionResult"
     ).innerHTML = `
-
-
     <h3>
     Converted Time
     </h3>


### PR DESCRIPTION
## Summary
Fixes the Timezone Converter so it correctly uses the selected "From Timezone" instead of silently defaulting to the browser's local timezone.

## Related Issue
Closes #267

## Changes
* The bug was actually in `convertTimezone()`, not `convertTime()` — the function the issue's line numbers (361-429) point to. `convertTime()` exists in the file but isn't wired to any UI element (confirmed via grep for callers); it's likely dead/legacy code and was left untouched.
* In `convertTimezone()`, the `from` variable was read from the `fromZone` dropdown but never used when constructing the source `Date` — the date was parsed in the browser's local system timezone regardless of the user's selection.
* Fix: the input date/time is now interpreted using the selected `from` zone via an offset-diff technique using `Intl.DateTimeFormat.formatToParts` (no external library needed, since the project has no build step/dependencies). This correctly accounts for each zone's DST rules on the specific date selected, rather than a hardcoded offset.

## Testing
* [ ] Added/updated tests
* [x] Tested locally (describe steps below)

## Testing Steps
1. Repro from the issue: From=London, To=Tokyo, convert a date → note result. Change From to Los Angeles, same date, convert again → result now correctly differs (previously identical in both cases).
2. Verified conversion math by hand: London (UTC+1, July)→Tokyo (UTC+9) = +8h shift; Los Angeles (UTC-7, July)→Tokyo = +16h shift. Both matched tool output exactly.
3. DST boundary test: London→Tokyo, same time, one date before UK's Oct 25 2026 DST end and one date after — output correctly shifted by exactly 1 hour across the boundary, confirming offsets are recalculated per-date rather than cached/hardcoded.

## Contributor Details
* Name: Tirth Panchori
* GitHub Username: Tirthpanchori
* Program (SSoC / GSSoC / Hacktoberfest / Other): SSoC 2026

## Checklist before requesting a review
* [x] Code follows the project's conventions
* [x] No secrets or `.env` values are committed
* [x] I have performed a self-review of my code
* [ ] Documentation has been updated if needed
* [x] CI passes
* [x] Linked the related issue above