### PR TITLE
fix: show feedback for empty email input

### DIFF
--- a/tools/email-validator/email-validator.js
+++ b/tools/email-validator/email-validator.js
@@ -95,11 +95,11 @@ function validateEmail() {
     const resultsCard = document.getElementById('resultsCard');
     const typoAction = document.getElementById('typoAction');
     
-    if (!email) {
-        if(window.showNotification) window.showNotification('Please enter an email address.', 'error');
-        return;
-    }
+   if (!email) {
+        alert('No text in the input field.');
     
+    return;
+}
     resultsCard.classList.add('visible');
     typoAction.style.display = 'none';
     typoAction.innerHTML = '';


### PR DESCRIPTION
## Summary

Adds user feedback when attempting to click analyze with empty input field.

## Closes #377  

## Changes

* Added an alert message when the analyze action is triggered without any text in input field.
* Preserved the existing analization behavior for text written in input field.

## Screenshots
### After:
<img width="1442" height="618" alt="image" src="https://github.com/user-attachments/assets/d22c068d-6ea1-42de-b7a1-f562f3bd2f5c" />


## Testing

* [x] Verified that an alert is shown when input field is empty.
