### PR TITLE
bug: fixed css sytax errors

### DIFF
--- a/tools/email-validator/email-validator.html
+++ b/tools/email-validator/email-validator.html
@@ -194,6 +194,7 @@
 .copy-btn:active {
     transform: translate(2px, 2px);
     box-shadow: 1px 1px 0px var(--border);
+}
         .clear-btn {
     background: var(--bg) !important;
     color: var(--text) !important;


### PR DESCRIPTION
## Summary

Fix CSS syntax error causing the CLEAR button to display incorrect theme colors.

## Related Issue

Closes #382 

<!-- Example: Closes #123 -->

## Changes

<!-- Bullet list of what changed and why. -->

* Fixed the missing closing brace in the `.copy-btn:active` CSS rule.
* Correctly separated the `.clear-btn` styles from the `.copy-btn:active` selector.
* Ensured the CLEAR button correctly applies theme-aware background and text colors.
* Improved UI consistency between the CLEAR button and the active application theme.

## Testing

<!-- How did you verify this works? -->

* [ ] Added/updated tests
* [x] Tested locally (describe steps below)

## Testing Steps

1. Open the Email Validator page.
2. Enter an email address to display the CLEAR button.
3. Verify that the CLEAR button displays the correct background and text colors.
4. Toggle between light and dark themes.
5. Confirm that the CLEAR button correctly adapts to the active theme.
6. Verify that the COPY button's active state still works as expected.

## Contributor Details

* Name: Lovepreet Kaur
* GitHub Username: @love25-codes 
* Program (SSoC / GSSoC / Hacktoberfest / Other): SSoC

## Checklist before requesting a review

* [x] Code follows the project's conventions
* [x] No secrets or `.env` values are committed
* [x] I have performed a self-review of my code
* [ ] Documentation has been updated if needed
* [ ] CI passes
* [x] Linked the related issue above