### PR TITLE
fix: remove duplicate catch block from index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -1461,10 +1461,6 @@ document
           console.error('Service Worker registration failed:', error);
         }
       });
-    } catch (error) {
-      console.error('Service Worker registration failed:', error);
-    }
-  });
 }
 </script>
 <script>


### PR DESCRIPTION
## Summary

<!-- One-sentence description of what this PR does. -->

Fixes the JavaScript syntax error in `index.html` caused by an unmatched duplicate `catch` block in the service worker registration logic.

## Related Issue

Closes #386 

<!-- Example: Closes #123 -->

## Changes

<!-- Bullet list of what changed and why. -->

* Removed the duplicate unmatched `catch` block from the service worker registration code.
* Removed the extra closing braces associated with the invalid duplicate block.
* Preserved the existing error handling for service worker registration failures.
* Ensured the remaining JavaScript code can execute without syntax errors.

## Testing

<!-- How did you verify this works? -->

* [ ] Added/updated tests
* [x] Tested locally (describe steps below)

## Testing Steps

1. Open the application locally in a browser.
2. Open the browser Developer Tools and check the Console for JavaScript syntax errors.
3. Verify that the homepage loads correctly without JavaScript parsing errors.
4. Verify that service worker registration executes correctly.
5. Verify that existing functionality such as tool search, filtering, the back-to-top button, and PWA functionality continues to work.

## Contributor Details

* Name: Lovepreet Kaur
* GitHub Username: @love25-codes 
* Program (SSoC / GSSoC / Hacktoberfest / Other): SSoC

## Checklist before requesting a review

* [x] Code follows the project's conventions
* [x] No secrets or `.env` values are committed
* [x] I have performed a self-review of my code
* [ ] Documentation has been updated if needed
* [ ] CI passes
* [x] Linked the related issue above