### PR TITLE
feat: add swap button for diff inputs

### DIFF
--- a/tools/diff-checker/diff-logic.js
+++ b/tools/diff-checker/diff-logic.js
@@ -112,3 +112,14 @@ function clearAll() {
     modifiedInput.value = '';
     outputDiv.innerHTML = '<div style="padding: 20px; color: #666; text-align: center;">Result will appear here...</div>';
 }
+
+
+function swapTexts() {
+    const original = document.getElementById("original");
+    const modified = document.getElementById("modified");
+
+    const temp = original.value;
+
+    original.value = modified.value;
+    modified.value = temp;
+}

--- a/tools/diff-checker/diff.html
+++ b/tools/diff-checker/diff.html
@@ -39,16 +39,29 @@
         <button class="dark-mode-toggle" onclick="toggleTheme()" id="themeBtn" aria-label="Toggle theme">DARK MODE</button>
     </header>
 
-    <div class="input-container">
-        <div class="input-box">
-            <label>Original Text</label>
-            <textarea id="original" placeholder="Paste original code/text here..."></textarea>
-        </div>
-        <div class="input-box">
-            <label>Modified Text</label>
-            <textarea id="modified" placeholder="Paste modified code/text here..."></textarea>
-        </div>
+ <div class="input-container">
+
+    <div class="input-box">
+        <label for="original">Original Text</label>
+        <textarea id="original" placeholder="Paste original code/text here..."></textarea>
     </div>
+
+    <div class="swap-container">
+        <button
+            class="swap-button"
+            onclick="swapTexts()"
+            aria-label="Swap original and modified text"
+            title="Swap original and modified text">
+            ⇄
+        </button>
+    </div>
+
+    <div class="input-box">
+        <label for="modified">Modified Text</label>
+        <textarea id="modified" placeholder="Paste modified code/text here..."></textarea>
+    </div>
+
+</div>
 
     <div class="controls">
         <button onclick="compareText()">🔍 Compare Differences</button>

--- a/tools/diff-checker/style.css
+++ b/tools/diff-checker/style.css
@@ -193,3 +193,61 @@
             background: var(--text);
             color: var(--bg);
         }
+.input-container {
+    display: flex;
+    align-items: stretch;
+    gap: 20px;
+    min-height: 200px;
+}
+
+.input-box {
+    flex: 1;
+    min-height: 100px;
+}
+
+.swap-container {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    flex-shrink: 0;
+}
+
+.swap-button {
+    width: 45px;
+    height: 45px;
+
+    border: 1px solid var(--border);
+    border-radius: 50%;
+
+    background: var(--surface);
+    color: var(--text);
+
+    font-size: 24px;
+    font-weight: bold;
+
+    cursor: pointer;
+
+    display: flex;
+    align-items: center;
+    justify-content: center;
+
+    transition: transform 0.25s ease, background-color 0.25s ease;
+}
+
+.swap-button:hover {
+    transform: rotate(180deg);
+}
+
+@media (max-width: 768px) {
+    .input-container {
+        flex-direction: column;
+    }
+
+    .swap-container {
+        margin: 10px 0;
+    }
+
+    .swap-button:hover {
+        transform: rotate(180deg);
+    }
+}


### PR DESCRIPTION
## Summary

Adds a Swap button between the Original Text and Modified Text input blocks to allow users to quickly exchange their contents.

## Related Issue

Closes #388 

<!-- Example: Closes #123 -->

## Changes

<!-- Bullet list of what changed and why. -->

* Added a Swap button between the Original Text and Modified Text input blocks.
* Added functionality to exchange the contents of both textareas without losing any data.
* Added hover interaction for the Swap button.
* Added responsive styling to ensure the Swap button works properly on smaller screens.
* Preserved the existing diff result until the user manually runs the comparison again.

## Testing

<!-- How did you verify this works? -->

* [ ] Added/updated tests
* [x] Tested locally (describe steps below)

## Testing Steps

1. Enter text or code into both the Original Text and Modified Text fields.
2. Click the Swap button positioned between the two input blocks.
3. Verify that the contents of both textareas are exchanged correctly.
4. Test swapping with one or both input fields empty.
5. Click the Swap button multiple times and verify that no data is lost.
6. Run the comparison after swapping and verify that the diff result reflects the updated inputs.
7. Verify that the button layout works correctly on both desktop and mobile screen sizes.
8. Verify that the feature works correctly in both light and dark themes.

## Screenshots:
### After:
<img width="1883" height="832" alt="image" src="https://github.com/user-attachments/assets/b8686ab4-51a1-41f6-aa1c-05f2fee8c75e" />


### After clicking swap and compare difference button:
<img width="1897" height="818" alt="image" src="https://github.com/user-attachments/assets/46104cda-7772-43a9-bf46-44b04b44676f" />



## Contributor Details

* Name: Lovepreet Kaur
* GitHub Username: @love25-codes 
* Program (SSoC / GSSoC / Hacktoberfest / Other): SSoC

## Checklist before requesting a review

* [x] Code follows the project's conventions
* [x] No secrets or `.env` values are committed
* [x] I have performed a self-review of my code
* [ ] Documentation has been updated if needed
* [ ] CI passes
* [x] Linked the related issue above