### PR TITLE
feat: add load sample text buttons

### DIFF
--- a/tools/diff-checker/diff-logic.js
+++ b/tools/diff-checker/diff-logic.js
@@ -112,3 +112,27 @@ function clearAll() {
     modifiedInput.value = '';
     outputDiv.innerHTML = '<div style="padding: 20px; color: #666; text-align: center;">Result will appear here...</div>';
 }
+
+function loadSample(inputId) {
+    const samples = {
+        original: `The weather was pleasant today.
+I went for a walk in the park.
+The trees were green and the birds were singing.
+After the walk, I stopped at a coffee shop.
+It was a peaceful and relaxing afternoon.`,
+
+        modified: `The weather was warm and pleasant today.
+I went for a walk in the nearby park.
+The trees were green and the birds were singing loudly.
+After the walk, I stopped at a small coffee shop.
+It was a peaceful and relaxing afternoon with beautiful weather.`
+    };
+
+    const input = document.getElementById(inputId);
+
+    if (!input || !samples[inputId]) {
+        return;
+    }
+
+    input.value = samples[inputId];
+}

--- a/tools/diff-checker/diff.html
+++ b/tools/diff-checker/diff.html
@@ -40,14 +40,37 @@
     </header>
 
     <div class="input-container">
-        <div class="input-box">
-            <label>Original Text</label>
-            <textarea id="original" placeholder="Paste original code/text here..."></textarea>
-        </div>
-        <div class="input-box">
-            <label>Modified Text</label>
-            <textarea id="modified" placeholder="Paste modified code/text here..."></textarea>
-        </div>
+       <div class="input-box">
+    <div class="label-row">
+        <label for="original">Original Text</label>
+        <button
+            type="button"
+            class="sample-button"
+            onclick="loadSample('original')">
+            Load Sample
+        </button>
+    </div>
+
+    <textarea
+        id="original"
+        placeholder="Paste original code/text here..."></textarea>
+</div>
+
+<div class="input-box">
+    <div class="label-row">
+        <label for="modified">Modified Text</label>
+        <button
+            type="button"
+            class="sample-button"
+            onclick="loadSample('modified')">
+            Load Sample
+        </button>
+    </div>
+
+    <textarea
+        id="modified"
+        placeholder="Paste modified code/text here..."></textarea>
+</div>
     </div>
 
     <div class="controls">

--- a/tools/diff-checker/style.css
+++ b/tools/diff-checker/style.css
@@ -193,3 +193,30 @@
             background: var(--text);
             color: var(--bg);
         }
+
+
+        .label-row {
+    display: flex;
+    align-items: center;
+    /* justify-content: space-betw; */
+    margin-bottom: 5px;
+    margin-left: 10px;
+}
+
+.label-row label {
+    margin-bottom: 0;
+    margin-left: 10px;
+}
+
+.sample-button {
+    padding: 5px 10px;
+    font-size: 0.8rem;
+    border: 1px solid var(--border);
+    border-radius: 4px;
+    margin-left: 10px;
+}
+
+.sample-button:hover {
+    background-color: var(--text);
+    color: var(--bg);
+}


### PR DESCRIPTION
## Summary

Adds separate Load Sample buttons beside the Original Text and Modified Text labels to populate the textareas with readable sample content for quick testing.

## Related Issue

Closes #390 

<!-- Example: Closes #123 -->

## Changes

<!-- Bullet list of what changed and why. -->

* Added a `Load Sample` button beside the Original Text label.
* Added a `Load Sample` button beside the Modified Text label.
* Added sample text related to a real-world scenario for easier demonstration of the diff checker.
* Added functionality to populate only the selected textarea when its corresponding button is clicked.
* Added meaningful differences between the Original and Modified sample text to make the comparison feature easier to test.
* Added styling for the sample buttons to match the existing UI and theme.

## Testing

<!-- How did you verify this works? -->

* [ ] Added/updated tests
* [x] Tested locally (describe steps below)

## Testing Steps

1. Open the Visual Diff Checker.
2. Click the `Load Sample` button beside Original Text and verify that only the Original Text textarea is populated.
3. Click the `Load Sample` button beside Modified Text and verify that only the Modified Text textarea is populated.
4. Click `Compare Differences` and verify that the differences between the sample texts are displayed correctly.
5. Verify that existing user input is replaced only in the textarea associated with the clicked button.
6. Verify that the buttons work correctly in both light and dark themes.
7. Verify that the layout remains usable on different screen sizes.


## Screenshots:
### After clicking load sample button on both sides:
<img width="1905" height="871" alt="image" src="https://github.com/user-attachments/assets/19efcaa2-fd51-4d78-8636-9765169c54b7" />



## Contributor Details

* Name: Lovepreet Kaur
* GitHub Username: @love25-codes 
* Program (SSoC / GSSoC / Hacktoberfest / Other): SSoC

## Checklist before requesting a review

* [x] Code follows the project's conventions
* [x] No secrets or `.env` values are committed
* [x] I have performed a self-review of my code
* [ ] Documentation has been updated if needed
* [ ] CI passes
* [x] Linked the related issue above