### PR TITLE
fix: prevent clear all button from being hidden

### DIFF
--- a/tools/diff-checker/diff.html
+++ b/tools/diff-checker/diff.html
@@ -32,12 +32,23 @@
 </head>
 
 <body>
-    <header>
-        <h1>Visual Diff Checker</h1>
-        <button class="secondary" onclick="clearAll()">Clear All</button>
+  <header>
+    <h1>Visual Diff Checker</h1>
 
-        <button class="dark-mode-toggle" onclick="toggleTheme()" id="themeBtn" aria-label="Toggle theme">DARK MODE</button>
-    </header>
+    <div class="header-actions">
+        <button class="secondary" onclick="clearAll()">
+            Clear All
+        </button>
+
+        <button
+            class="dark-mode-toggle"
+            onclick="toggleTheme()"
+            id="themeBtn"
+            aria-label="Toggle theme">
+            DARK MODE
+        </button>
+    </div>
+</header>
 
     <div class="input-container">
         <div class="input-box">

--- a/tools/diff-checker/style.css
+++ b/tools/diff-checker/style.css
@@ -20,13 +20,7 @@
             box-sizing: border-box;
         }
 
-        header {
-            display: flex;
-            justify-content: space-between;
-            align-items: center;
-            margin-bottom: 15px;
-            gap: 15px;
-        }
+
 
         h1 {
             margin: 0;
@@ -162,10 +156,7 @@
             background-color: var(--text);
             color: var(--bg);
         }
-        .secondary {
-            position: relative;
-            right: 20px;
-        }
+
         .secondary:hover{
             background-color: var(--text);
             color: var(--bg);
@@ -193,3 +184,38 @@
             background: var(--text);
             color: var(--bg);
         }
+header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin-bottom: 15px;
+    gap: 20px;
+}
+
+.header-actions {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    flex-shrink: 0;
+}
+
+.header-actions .dark-mode-toggle {
+    position: static;
+}
+
+.header-actions .secondary {
+    display: inline-block;
+    visibility: visible;
+    opacity: 1;
+}
+
+@media (max-width: 600px) {
+    header {
+        flex-wrap: wrap;
+    }
+
+    .header-actions {
+        width: 100%;
+        justify-content: flex-end;
+    }
+}


### PR DESCRIPTION
## Summary

Fixes the header layout so that the Clear All button remains visible and properly aligned with the Dark Mode button.

## Related Issue

Closes #392 

<!-- Example: Closes #123 -->

## Changes

<!-- Bullet list of what changed and why. -->

* Added a dedicated flex container for the header action buttons.
* Added consistent spacing between the Clear All and Dark Mode buttons.
* Overrode the absolute positioning of the Dark Mode button within the header actions container.
* Ensured the Clear All button remains visible and accessible.
* Added responsive styling to prevent header buttons from overlapping on smaller screens.
* Preserved the existing Clear All and Dark Mode functionality.

## Testing

<!-- How did you verify this works? -->

* [ ] Added/updated tests
* [x] Tested locally (describe steps below)

## Testing Steps

1. Open the Visual Diff Checker and verify that both the Clear All and Dark Mode buttons are visible in the header.
2. Click the Clear All button and verify that both input fields and the diff output are cleared.
3. Click the Dark Mode button and verify that the theme changes while both header buttons remain visible.
4. Resize the browser window and verify that the buttons do not overlap or disappear.
5. Verify that the layout works correctly on smaller screen sizes.

## Screenshots:
### Before:
<img width="1902" height="322" alt="image" src="https://github.com/user-attachments/assets/ac599c93-9dcf-48be-a855-ad202669c38e" />


### After:
<img width="1892" height="260" alt="image" src="https://github.com/user-attachments/assets/c3ae9970-08ee-4757-b988-47b3abb7f313" />


## Contributor Details

* Name: Lovepreet Kaur
* GitHub Username: @love25-codes 
* Program (SSoC / GSSoC / Hacktoberfest / Other): SSoC

## Checklist before requesting a review

* [x] Code follows the project's conventions
* [x] No secrets or `.env` values are committed
* [x] I have performed a self-review of my code
* [ ] Documentation has been updated if needed
* [ ] CI passes
* [x] Linked the related issue above