### PR TITLE
fix: show notification when formatting empty input

### DIFF
--- a/tools/linkedin-text-formatter/formatter.js
+++ b/tools/linkedin-text-formatter/formatter.js
@@ -1,14 +1,26 @@
 const input = document.getElementById("input");
 const output = document.getElementById("output");
+function validateInput() {
+  if (!input.value.trim()) {
+    output.value = "";
 
+    if (window.notify) {
+      notify.error("Please enter some text before formatting.");
+    } else {
+      alert("Please enter some text before formatting.");
+    }
+
+    return false;
+  }
+
+  return true;
+}
 function transformText(style) {
   const text = input.value;
 
-  if (!text.trim()) {
-    output.value = "";
+ if (!validateInput()) {
     return;
-  }
-
+}
   output.value = [...text].map((char) => convertChar(char, style)).join("");
 }
 
@@ -103,16 +115,23 @@ document.getElementById("clearBtn").addEventListener("click", () => {
 });
 
 document.getElementById("smallCapsBtn").addEventListener("click", () => {
+    if (!validateInput()) return;
+
     output.value = toSmallCaps(input.value);
 });
 
+
 document.getElementById("underlineBtn").addEventListener("click", () => {
+
+  if (!validateInput()) return;
     output.value = [...input.value]
         .map(char => char === " " ? " " : char + "\u0332")
         .join("");
 });
 
+
 document.getElementById("strikeBtn").addEventListener("click", () => {
+  if (!validateInput()) return;
     output.value = [...input.value]
         .map(char => char === " " ? " " : char + "\u0336")
         .join("");


### PR DESCRIPTION
## Summary

Adds input validation for all formatting actions and displays an error notification when users attempt to format an empty input, improving usability and providing consistent feedback.

## Related Issue

Closes #394 

<!-- Example: Closes #123 -->

## Changes

* Added a reusable `validateInput()` helper function to centralize input validation.
* Prevented formatting when the input field is empty or contains only whitespace.
* Added user feedback by displaying an error notification when a formatting button is clicked without any input.
* Applied input validation consistently across all formatting actions:
  * Bold
  * Italic
  * Bold Italic
  * Small Caps
  * Underline
  * Strikethrough
* Updated the notification implementation to use the project's existing `notify` utility instead of the unsupported `showNotification()` function.
* Preserved the existing formatting behavior for valid input.

## Testing

<!-- How did you verify this works? -->

* [ ] Added/updated tests
* [x] Tested locally (describe steps below)

## Testing Steps

1. Open the LinkedIn Text Formatter.
2. Leave the input field empty.
3. Click each formatting button (Bold, Italic, Bold Italic, Small Caps, Underline, and Strikethrough).
4. Verify that an error notification appears indicating that text must be entered before formatting.
5. Enter valid text into the input field.
6. Click each formatting button again and verify that the formatted output is generated correctly.
7. Verify that the Copy Output and Clear functionalities continue to work as expected.

## Contributor Details

* Name: Lovepreet Kaur
* GitHub Username: @love25-codes 
* Program (SSoC / GSSoC / Hacktoberfest / Other): SSoC

## Checklist before requesting a review

* [x] Code follows the project's conventions
* [x] No secrets or `.env` values are committed
* [x] I have performed a self-review of my code
* [ ] Documentation has been updated if needed
* [ ] CI passes
* [x] Linked the related issue above