### PR TITLE
fix: copy output alert fixed

### DIFF
--- a/tools/linkedin-text-formatter/formatter.js
+++ b/tools/linkedin-text-formatter/formatter.js
@@ -91,10 +91,7 @@ document.getElementById("copyBtn").addEventListener("click", async () => {
   if (!output.value) return;
 
   await navigator.clipboard.writeText(output.value);
-
-  if (window.showNotification) {
-    showNotification("Copied to clipboard!", "success");
-  }
+notify.success("Copied to clipboard!");
 });
 
 document.getElementById("clearBtn").addEventListener("click", () => {


### PR DESCRIPTION
## Summary

Adds user feedback when attempting to click copy output when text is written in input field.

## Closes #396 

## Changes

* Added an alert messageusing notify.sucess when the copy action is triggered with any text present in output field.

## Screenshots
### After:
<img width="1567" height="905" alt="image" src="https://github.com/user-attachments/assets/8dc95f6e-d5b1-4a71-a773-fd5763bad95b" />


## Testing

* [x] Verified that an alert is shown when input field is empty.
