### PR TITLE
fixed input focus after clicking format buttons

### DIFF
--- a/tools/linkedin-text-formatter/formatter.js
+++ b/tools/linkedin-text-formatter/formatter.js
@@ -1,5 +1,13 @@
 const input = document.getElementById("input");
 const output = document.getElementById("output");
+
+
+function restoreInputFocus(start, end) {
+  input.focus();
+  input.setSelectionRange(start, end);
+}
+
+
 function validateInput() {
   if (!input.value.trim()) {
     output.value = "";
@@ -16,12 +24,20 @@ function validateInput() {
   return true;
 }
 function transformText(style) {
+  if (!validateInput()) {
+    return;
+  }
+
+  const start = input.selectionStart;
+  const end = input.selectionEnd;
+
   const text = input.value;
 
- if (!validateInput()) {
-    return;
-}
-  output.value = [...text].map((char) => convertChar(char, style)).join("");
+  output.value = [...text]
+    .map((char) => convertChar(char, style))
+    .join("");
+
+  restoreInputFocus(start, end);
 }
 
 function toSmallCaps(text) {
@@ -107,29 +123,45 @@ notify.success("Copied to clipboard!");
 });
 
 document.getElementById("clearBtn").addEventListener("click", () => {
-  input.value = "";
-  output.value = "";
+    input.value = "";
+    output.value = "";
+    input.focus();
 });
 
 document.getElementById("smallCapsBtn").addEventListener("click", () => {
     if (!validateInput()) return;
 
+    const start = input.selectionStart;
+    const end = input.selectionEnd;
+
     output.value = toSmallCaps(input.value);
+
+    restoreInputFocus(start, end);
 });
 
-
 document.getElementById("underlineBtn").addEventListener("click", () => {
+    if (!validateInput()) return;
 
-  if (!validateInput()) return;
+    const start = input.selectionStart;
+    const end = input.selectionEnd;
+
     output.value = [...input.value]
         .map(char => char === " " ? " " : char + "\u0332")
         .join("");
+
+    restoreInputFocus(start, end);
 });
 
 
 document.getElementById("strikeBtn").addEventListener("click", () => {
-  if (!validateInput()) return;
+    if (!validateInput()) return;
+
+    const start = input.selectionStart;
+    const end = input.selectionEnd;
+
     output.value = [...input.value]
         .map(char => char === " " ? " " : char + "\u0336")
         .join("");
+
+    restoreInputFocus(start, end);
 });


### PR DESCRIPTION
## Summary

Fixes the input textarea losing focus after applying text formatting by restoring focus and preserving the cursor/selection position after every formatting action.

## Related Issue

Closes #400 

<!-- Example: Closes #123 -->

## Changes

* Added a reusable helper to restore focus to the input textarea after formatting.
* Preserved the user's cursor position and text selection using `selectionStart` and `selectionEnd`.
* Updated the common `transformText()` function to save and restore cursor position after generating formatted output.
* Applied the same focus restoration behavior to all formatting actions, including:
  * Bold
  * Italic
  * Bold Italic
  * Small Caps
  * Underline
  * Strikethrough
* Improved the writing experience by allowing users to continue typing immediately after clicking any formatting button.
* Ensured no changes to the existing text formatting logic or output generation.

## Testing

* [ ] Added/updated tests
* [x] Tested locally (describe steps below)

## Testing Steps

1. Open the LinkedIn Text Formatter in the browser.
2. Type text into the input textarea and place the cursor at different positions (including selecting a range of text).
3. Click each formatting button (Bold, Italic, Bold Italic, Small Caps, Underline, and Strikethrough).
4. Verify that:
   - The formatted text is generated correctly in the output textarea.
   - The input textarea automatically regains focus.
   - The cursor or selected text is preserved whenever possible.
   - You can continue typing immediately without clicking back into the input field.
5. Repeat the above steps for all formatting actions to ensure consistent behavior.

## Contributor Details

* Name: Lovepreet Kaur
* GitHub Username: @love25-codes 
* Program (SSoC / GSSoC / Hacktoberfest / Other): SSoC

## Checklist before requesting a review

* [x] Code follows the project's conventions
* [x] No secrets or `.env` values are committed
* [x] I have performed a self-review of my code
* [ ] Documentation has been updated if needed
* [x] CI passes
* [x] Linked the related issue above