### PR TITLE
fix(linkedin-text-formatter): show notification when output is empty

### DIFF
--- a/tools/linkedin-text-formatter/formatter.js
+++ b/tools/linkedin-text-formatter/formatter.js
@@ -99,12 +99,19 @@ document.getElementById("boldItalicBtn").addEventListener("click", () => {
   transformText("boldItalic");
 });
 
-document.getElementById("copyBtn").addEventListener("click", async () => {
-  if (!output.value) return;
 
-  await navigator.clipboard.writeText(output.value);
-notify.success("Copied to clipboard!");
+document.getElementById("copyBtn").addEventListener("click", async () => {
+  const text = output.value.trim();
+
+  if (!text) {
+      notify.error("Nothing to copy.");
+    return;
+  }
+
+  await navigator.clipboard.writeText(text);
+    notify.success("Copied to clipboard!");
 });
+
 
 document.getElementById("clearBtn").addEventListener("click", () => {
   input.value = "";


### PR DESCRIPTION
## Summary

Adds user feedback when attempting to click copy output when output field is empty.

## Closes #402 

## Changes

* Added an alert message using notify.error when the copy action is triggered without any text present in output field.

## Screenshots
### After:
<img width="1508" height="876" alt="image" src="https://github.com/user-attachments/assets/7e44700d-8da8-4886-a62b-389b6e2fd367" />


## Testing

* [x] Verified that an alert is shown when output field is empty.

## Contributor Details:
### Name: Lovepreet Kaur
### Github: @love25-codes 
### Program: SSoC
