### PR TITLE
output placeholder added

### DIFF
--- a/tools/linkedin-text-formatter/formatter.html
+++ b/tools/linkedin-text-formatter/formatter.html
@@ -170,7 +170,7 @@
       </div>
 
       <label>Output</label>
-      <textarea id="output" readonly></textarea>
+      <textarea id="output" placeholder="Formatted text will appear here..." readonly></textarea>
 
       <div class="btn-group">
         <button id="copyBtn">Copy Output</button>


### PR DESCRIPTION
## Summary

Add a descriptive placeholder to the output textarea so users know where the formatted LinkedIn text will appear when the field is empty.

## Related Issue

Closes #405 

<!-- Example: Closes #123 -->

## Changes

* Added a placeholder to the read-only output textarea with the text: `Formatted text will appear here...`
* Ensured the placeholder is visible when the output is empty (on initial page load and after clearing the output).
* Verified that the placeholder automatically disappears when formatted text is generated.
* Preserved all existing formatting, copy, and output functionality without introducing behavioral changes.
* Improved the overall user experience with a simple, non-intrusive UI enhancement.

## Testing

<!-- How did you verify this works? -->

* [ ] Added/updated tests
* [x] Tested locally (describe steps below)

## Testing Steps

1. Open the LinkedIn Text Formatter application.
2. Verify that the output textarea displays the placeholder: `Formatted text will appear here...`
3. Enter text in the input field and click the format button.
4. Confirm that the formatted text appears and the placeholder disappears.
5. Clear the output (or refresh the page if applicable) and verify that the placeholder reappears.
6. Test the copy functionality to ensure it continues to work as expected when output is present.

## Screenshots:
### After:
<img width="1136" height="255" alt="image" src="https://github.com/user-attachments/assets/ee9096db-cc8a-44a8-b3f2-1a99e0b2c79b" />


## Contributor Details

* Name: Lovepreet Kaur
* GitHub Username: @love25-codes 
* Program (SSoC / GSSoC / Hacktoberfest / Other): SSoC

## Checklist before requesting a review

* [x] Code follows the project's conventions
* [x] No secrets or `.env` values are committed
* [x] I have performed a self-review of my code
* [ ] Documentation has been updated if needed
* [ ] CI passes
* [x] Linked the related issue above