### PR TITLE
duplicate block removed

### DIFF
--- a/tools/diff-checker/diff.html
+++ b/tools/diff-checker/diff.html
@@ -84,11 +84,6 @@
 </div>
     </div>
 
-    <div class="input-box">
-        <label for="modified">Modified Text</label>
-        <textarea id="modified" placeholder="Paste modified code/text here..."></textarea>
-    </div>
-
 </div>
 
     <div class="controls">


### PR DESCRIPTION
## Summary

Removes the duplicate **"Modified Text"** input block from the Visual Diff Checker to ensure a single input field is displayed and eliminates the duplicate `id="modified"`.

## Related Issue

Closes #412 

<!-- Example: Closes #123 -->

## Changes

* Removed the unintended duplicate **Modified Text** input section from `tools/diff-checker/diff.html`.
* Eliminated the duplicate `id="modified"` to maintain valid HTML.
* Fixed the UI so only one **Modified Text** input box is rendered.
* Ensured JavaScript functions referencing `id="modified"` target the correct element without ambiguity.

## Testing

* [ ] Added/updated tests
* [x] Tested locally (describe steps below)

## Testing Steps

1. Launch the Visual Diff Checker locally.
2. Verify that only one **Modified Text** input box is displayed.
3. Confirm that text comparison and all existing features (e.g., Load Sample, Compare Differences) continue to function correctly.
4. Inspect the HTML to ensure only one element with `id="modified"` exists.

## Contributor Details

* **Name:** Lovepreet Kaur
* **GitHub Username:** @love25-codes 
* **Program (SSoC / GSSoC / Hacktoberfest / Other):** SSoC

## Checklist before requesting a review

* [x] Code follows the project's conventions
* [x] No secrets or `.env` values are committed
* [x] I have performed a self-review of my code
* [ ] Documentation has been updated if needed
* [ ] CI passes
* [x] Linked the related issue above