### PR TITLE
Improve visual distinction for export composite button

### DIFF
--- a/tools/vision-studio/vision_core.html
+++ b/tools/vision-studio/vision_core.html
@@ -147,12 +147,30 @@
             transition: all 0.2s ease;
         }
 
+
         .btn:hover {
             border-color: var(--accent);
             background: var(--tag-bg);
             border-color: var(--text);
             transform: translateY(-1px);
         }
+        .btn-export {
+    background: #16a34a;
+    color: #fff;
+    border: 1px solid #16a34a;
+    transition: all 0.2s ease;
+}
+
+.btn-export:hover {
+    background: #15803d;
+    color: #fff;
+    border-color: #15803d;
+    transform: translateY(-1px);
+}
+
+.btn-export:active {
+    transform: translateY(0);
+}
 
         .btn.active {
             background: var(--accent);
@@ -163,6 +181,7 @@
         #themeBtn {
             top: 20px;
         }
+
         /* STICKER LAB */
         .sticker-grid {
             display: grid;
@@ -361,8 +380,13 @@
         </div>
         <div class="control-group">
             <div class="group-title">FILE</div>
-            <button class="btn" onclick="document.getElementById('file-input').click()">LOAD IMAGE</button>
-            <button class="btn" onclick="vision.export()">EXPORT COMPOSITE</button>
+            <button class="btn" onclick="document.getElementById('file-input').click()">
+                📂 LOAD IMAGE
+            </button>
+
+            <button class="btn btn-export" onclick="vision.export()">
+                ⬇ EXPORT COMPOSITE
+            </button>
             <input type="file" id="file-input" accept="image/*" hidden onchange="vision.handleFile(this.files[0])">
         </div>
 


### PR DESCRIPTION
## Summary

Improves the visual distinction between the **Load Image** and **Export Composite** buttons by introducing a dedicated styling for the export button, making the primary export action more prominent and easier to identify.

## Related Issue

Closes #416

<!-- Example: Closes #123 -->

## Changes

* Added a dedicated `.btn-export` CSS class for the **Export Composite** button.
* Applied a green color scheme to visually differentiate the export action from other buttons.
* Preserved the existing hover and active animations for a consistent user experience.
* Improved the visual hierarchy of the toolbar without affecting existing functionality.

## Testing

* [ ] Added/updated tests
* [x] Tested locally (describe steps below)

## Testing Steps

1. Open the Vision Studio page.
2. Verify that the **Load Image** button retains the default styling.
3. Confirm that the **Export Composite** button appears with the new green styling.
4. Hover over the **Export Composite** button and ensure the text remains visible.
5. Load an image and export it to verify the functionality is unaffected.

## Screenshots:
### After:
<img width="376" height="185" alt="image" src="https://github.com/user-attachments/assets/585e20f5-6113-4547-bbf4-f6ad2fec6351" />


<img width="378" height="180" alt="image" src="https://github.com/user-attachments/assets/856d5132-1cf5-4cd6-930a-d8582ab4ff7f" />


## Contributor Details

* Name: Lovepreet Kaur 
* GitHub Username: @love25-codes 
* Program (SSoC / GSSoC / Hacktoberfest / Other): SSoC

## Checklist before requesting a review

* [x] Code follows the project's conventions
* [x] No secrets or `.env` values are committed
* [x] I have performed a self-review of my code
* [ ] Documentation has been updated if needed
* [ ] CI passes
* [x] Linked the related issue above