### PR TITLE
reset button added successfully

### DIFF
--- a/tools/vision-studio/vision_core.html
+++ b/tools/vision-studio/vision_core.html
@@ -154,17 +154,20 @@
             transform: translateY(-1px);
         }
 
-     .btn.active {
-    background: var(--accent);
-    color: var(--bg);
-    border-color: var(--accent);
-}
-.btn.active:hover {
-    filter: brightness(1.08);
-}
+        .btn.active {
+            background: var(--accent);
+            color: var(--bg);
+            border-color: var(--accent);
+        }
+
+        .btn.active:hover {
+            filter: brightness(1.08);
+        }
+
         #themeBtn {
             top: 20px;
         }
+
         /* STICKER LAB */
         .sticker-grid {
             display: grid;
@@ -346,6 +349,21 @@
         .c-sys {
             color: var(--muted);
         }
+
+   .btn-reset {
+    background: transparent;
+    color: #ff6b6b;
+    border: 1px dashed #ff6b6b;
+    letter-spacing: 1px;
+    font-weight: 700;
+    transition: all 0.2s ease;
+}
+
+.btn-reset:hover {
+    background: rgba(255, 107, 107, 0.12);
+    border-style: solid;
+    box-shadow: 0 0 12px rgba(255,107,107,0.35);
+}
     </style>
     <link rel="stylesheet" href="../../theme.css">
 </head>
@@ -365,6 +383,9 @@
             <div class="group-title">FILE</div>
             <button class="btn" onclick="document.getElementById('file-input').click()">LOAD IMAGE</button>
             <button class="btn" onclick="vision.export()">EXPORT COMPOSITE</button>
+           <button class="btn btn-reset" onclick="vision.resetEditor()">
+    ↺ RESET EDITOR
+</button>
             <input type="file" id="file-input" accept="image/*" hidden onchange="vision.handleFile(this.files[0])">
         </div>
 
@@ -768,6 +789,44 @@
                 this.canvas.height = this.image.height;
                 this.canvas.style.width = (this.image.width * scale) + "px";
                 this.canvas.style.height = (this.image.height * scale) + "px";
+            },
+
+            resetEditor: function () {
+
+                // Do nothing if no image is loaded
+                if (!this.image) {
+                    notify.info("Load an image first!");
+                    return;
+                }
+
+                // Reset rotation and zoom values
+                this.params.rot = 0;
+                this.params.crop = 1.0;
+
+                // Reset filter
+                this.currentShader = "normal";
+
+                // Reset rotation slider and label
+                document.getElementById("slider-rot").value = 0;
+                document.getElementById("val-rot").innerText = "0";
+
+                // Reset zoom slider and label
+                document.getElementById("slider-crop").value = 1.0;
+                document.getElementById("val-crop").innerText = "1.0";
+
+                // Remove all stickers
+                stickers.items.forEach(sticker => {
+                    sticker.el.remove();
+                });
+
+                stickers.items = [];
+                stickers.selectedId = null;
+
+                // Re-render image
+                this.render();
+
+                // Log message
+                this.log("Editor reset successfully", "c-gpu");
             },
 
             export: function () {


### PR DESCRIPTION
## Summary

Adds a **Reset Editor** feature to Vision Studio, allowing users to restore the editor to its default state with a single click.

## Related Issue

Closes #420 

<!-- Example: Closes #123 -->

## Changes

* Added a **Reset Editor** button to the File section of the sidebar.
* Implemented a `vision.resetEditor()` method to restore the editor to its default state.
* Reset image rotation to **0°**.
* Reset image zoom to **1.0x**.
* Reset the active filter to **Normal**.
* Updated rotation and zoom sliders along with their displayed values.
* Removed all stickers from the canvas and cleared the current sticker selection.
* Automatically re-rendered the canvas after resetting.
* Added a system log entry indicating that the editor has been successfully reset.
* Included a safety check to prevent resetting before an image is loaded.

## Testing

<!-- How did you verify this works? -->

* [ ] Added/updated tests
* [x] Tested locally (describe steps below)

## Testing Steps

1. Open Vision Studio and load an image.
2. Apply different filters, rotate the image, zoom in/out, and add multiple stickers.
3. Click the **Reset Editor** button.
4. Verify that:
   - Rotation resets to **0°**.
   - Zoom resets to **1.0x**.
   - Filter changes back to **Normal**.
   - All stickers are removed.
   - No sticker remains selected.
   - The canvas is re-rendered correctly.
   - A success log is displayed in the terminal.

## Contributor Details

* Name: Lovepreet Kaur
* GitHub Username: @love25-codes 
* Program (SSoC / GSSoC / Hacktoberfest / Other): SSoC

## Checklist before requesting a review

* [x] Code follows the project's conventions
* [x] No secrets or `.env` values are committed
* [x] I have performed a self-review of my code
* [ ] Documentation has been updated if needed
* [ ] CI passes
* [x] Linked the related issue above