### PR TITLE
sticker drag boundary implemented

### DIFF
--- a/tools/vision-studio/vision_core.html
+++ b/tools/vision-studio/vision_core.html
@@ -154,32 +154,35 @@
             border-color: var(--text);
             transform: translateY(-1px);
         }
+
         .btn-export {
-    background: #16a34a;
-    color: #fff;
-    border: 1px solid #16a34a;
-    transition: all 0.2s ease;
-}
+            background: #16a34a;
+            color: #fff;
+            border: 1px solid #16a34a;
+            transition: all 0.2s ease;
+        }
 
-.btn-export:hover {
-    background: #15803d;
-    color: #fff;
-    border-color: #15803d;
-    transform: translateY(-1px);
-}
+        .btn-export:hover {
+            background: #15803d;
+            color: #fff;
+            border-color: #15803d;
+            transform: translateY(-1px);
+        }
 
-.btn-export:active {
-    transform: translateY(0);
-}
+        .btn-export:active {
+            transform: translateY(0);
+        }
 
-     .btn.active {
-    background: var(--accent);
-    color: var(--bg);
-    border-color: var(--accent);
-}
-.btn.active:hover {
-    filter: brightness(1.08);
-}
+        .btn.active {
+            background: var(--accent);
+            color: var(--bg);
+            border-color: var(--accent);
+        }
+
+        .btn.active:hover {
+            filter: brightness(1.08);
+        }
+
         #themeBtn {
             top: 20px;
         }
@@ -587,8 +590,17 @@
                 const dy = e.clientY - this.startY;
 
                 if (this.dragging) {
-                    s.x = this.initialParams.x + dx;
-                    s.y = this.initialParams.y + dy;
+                    const layerWidth = this.layer.clientWidth;
+                    const layerHeight = this.layer.clientHeight;
+
+                    let newX = this.initialParams.x + dx;
+                    let newY = this.initialParams.y + dy;
+
+                    newX = Math.max(0, Math.min(newX, layerWidth - s.w));
+                    newY = Math.max(0, Math.min(newY, layerHeight - s.h));
+
+                    s.x = newX;
+                    s.y = newY;
                 }
                 else if (this.resizing) {
                     s.w = Math.max(20, this.initialParams.w + dx);


### PR DESCRIPTION
## Summary

Fixes a bug in Vision Studio by preventing stickers from being dragged outside the composition canvas while preserving the existing drag behavior.

## Related Issue

Closes #422 

<!-- Example: Closes #123 -->

## Changes

* Added boundary checks during sticker dragging to keep stickers within the composition canvas.
* Clamped the sticker's horizontal position to prevent it from moving beyond the left and right edges.
* Clamped the sticker's vertical position to prevent it from moving beyond the top and bottom edges.
* Used the composition layer's dimensions to calculate valid drag boundaries dynamically.
* Preserved the existing drag experience while ensuring stickers remain fully visible within the canvas.

## Testing

<!-- How did you verify this works? -->

* [ ] Added/updated tests
* [x] Tested locally (describe steps below)

## Testing Steps

1. Open Vision Studio and load a base image.
2. Add one or more stickers to the canvas.
3. Drag stickers toward each edge of the composition canvas.
4. Verify that stickers stop at the canvas boundaries and cannot be dragged outside.
5. Confirm that sticker dragging remains smooth and other interactions (resize, rotate, delete) continue to work as expected.

## Contributor Details

* Name: Lovepreet Kaur
* GitHub Username: @love25-codes 
* Program (SSoC / GSSoC / Hacktoberfest / Other): SSoC

## Checklist before requesting a review

* [x] Code follows the project's conventions
* [x] No secrets or `.env` values are committed
* [x] I have performed a self-review of my code
* [ ] Documentation has been updated if needed
* [ ] CI passes
* [x] Linked the related issue above