### PR TITLE
recent history feature added

### DIFF
--- a/tools/linkedin-text-formatter/formatter.html
+++ b/tools/linkedin-text-formatter/formatter.html
@@ -114,6 +114,37 @@
         color: #fff;
       }
 
+      #historySection {
+    margin-top: 30px;
+}
+
+#historySection h2 {
+    margin-bottom: 15px;
+}
+
+.history-item {
+    border: 2px solid var(--border);
+    padding: 12px;
+    margin-bottom: 12px;
+    cursor: pointer;
+}
+
+.history-item:hover {
+    background: var(--tag-bg);
+}
+
+.history-style {
+    color: var(--muted);
+    font-size: 0.9rem;
+}
+
+.history-item textarea {
+    min-height: 60px;
+    margin-top: 10px;
+    width: 100%;
+    resize: vertical;
+}
+
       @media (max-width: 600px) {
         button {
           width: 100%;
@@ -211,6 +242,16 @@
         <button id="copyBtn">Copy Output</button>
         <button id="clearBtn">Clear</button>
       </div>
+
+      <hr>
+
+<section id="historySection">
+  <h2>Recent History</h2>
+
+  <div id="historyList">
+    <p>No recent conversions.</p>
+  </div>
+</section>
     </main>
 
     <footer>

--- a/tools/linkedin-text-formatter/formatter.js
+++ b/tools/linkedin-text-formatter/formatter.js
@@ -5,6 +5,70 @@ const output = document.getElementById("output");
 const charCount = document.getElementById("charCount");
 const wordCount = document.getElementById("wordCount");
 
+let history = [];
+
+const styleNames = {
+  bold: "Bold",
+  italic: "Italic",
+  boldItalic: "Bold Italic",
+  smallCaps: "Small Caps",
+  underline: "Underline",
+  strike: "Strikethrough",
+};
+
+function addToHistory(inputText, style, outputText) {
+
+    const latest = history[0];
+
+    if (
+        latest &&
+        latest.input === inputText &&
+        latest.style === style &&
+        latest.output === outputText
+    ) {
+        return;
+    }
+
+    history.unshift({
+        input: inputText,
+        style,
+        output: outputText
+    });
+
+    if (history.length > 10) {
+        history.pop();
+    }
+
+    renderHistory();
+}
+
+function renderHistory() {
+
+    const container = document.getElementById("historyList");
+
+    if (history.length === 0) {
+
+        container.innerHTML =
+            "<p>No recent conversions.</p>";
+
+        return;
+    }
+
+    container.innerHTML = history
+        .map((item, index) => `
+           <div class="history-item">
+    <strong>${item.input}</strong>
+
+    <div class="history-style">
+        Style: ${item.style}
+    </div>
+
+
+</div>
+        `)
+        .join("");
+}
+
 function validateInput() {
   if (!input.value.trim()) {
     output.value = "";
@@ -45,11 +109,17 @@ function transformText(style) {
 
   const text = input.value;
 
-  output.value = [...text]
-    .map((char) => convertChar(char, style))
-    .join("");
+ output.value = [...text]
+  .map((char) => convertChar(char, style))
+  .join("");
 
-  restoreInputFocus(start, end);
+addToHistory(
+  input.value,
+  styleNames[style],
+  output.value
+);
+
+restoreInputFocus(start, end);
 }
 
 function toSmallCaps(text) {
@@ -153,9 +223,15 @@ document.getElementById("smallCapsBtn").addEventListener("click", () => {
     const start = input.selectionStart;
     const end = input.selectionEnd;
 
-    output.value = toSmallCaps(input.value);
+  output.value = toSmallCaps(input.value);
 
-    restoreInputFocus(start, end);
+addToHistory(
+  input.value,
+  styleNames.smallCaps,
+  output.value
+);
+
+restoreInputFocus(start, end);
 });
 
 document.getElementById("underlineBtn").addEventListener("click", () => {
@@ -167,6 +243,12 @@ document.getElementById("underlineBtn").addEventListener("click", () => {
     output.value = [...input.value]
         .map(char => char === " " ? " " : char + "\u0332")
         .join("");
+
+        addToHistory(
+  input.value,
+  styleNames.underline,
+  output.value
+);
 
     restoreInputFocus(start, end);
 });
@@ -181,6 +263,14 @@ document.getElementById("strikeBtn").addEventListener("click", () => {
     output.value = [...input.value]
         .map(char => char === " " ? " " : char + "\u0336")
         .join("");
+
+        addToHistory(
+  input.value,
+  styleNames.strike,
+  output.value
+);
+
+restoreInputFocus(start, end);
 });
 
 


### PR DESCRIPTION
## Summary

Add a Recent History section to the LinkedIn Text Formatter that stores and displays the last 10 successful conversions.

## Related Issue

Closes #404 

<!-- Example: Closes #123 -->

## Changes

* Added a **Recent History** section below the output area.
* Introduced a history array to store recent formatting conversions.
* Limited history to the **10 most recent** conversions.
* Prevented **consecutive duplicate** history entries from being added.
* Displayed the **original input text** and **formatting style** for each history item.
* Added styling for the Recent History section to match the existing UI.
* Kept the existing formatting functionality unchanged.

## Testing

<!-- How did you verify this works? -->

* [ ] Added/updated tests
* [x] Tested locally (describe steps below)

## Testing Steps

1. Open the LinkedIn Text Formatter.
2. Enter text and apply different formatting styles (Bold, Italic, Small Caps, etc.).
3. Verify that each successful conversion is added to the top of the Recent History section.
4. Apply the same formatting consecutively and confirm that no duplicate history entry is created.
5. Perform more than 10 conversions and verify that only the latest 10 entries are retained.
6. Confirm that all existing formatting, copy, and clear functionality continue to work as expected.

## Contributor Details

* Name: Lovepreet Kaur
* GitHub Username: @love25-codes 
* Program (SSoC / GSSoC / Hacktoberfest / Other): SSoC

## Checklist before requesting a review

* [x] Code follows the project's conventions
* [x] No secrets or `.env` values are committed
* [x] I have performed a self-review of my code
* [ ] Documentation has been updated if needed
* [ ] CI passes
* [x] Linked the related issue above