### PR TITLE
copy html notification added

### DIFF
--- a/tools/markdown-editor/editor.js
+++ b/tools/markdown-editor/editor.js
@@ -58,19 +58,19 @@ clearBtn.addEventListener('click', () => {
 });
 
 copyHtmlBtn.addEventListener('click', async () => {
+  const html = preview.innerHTML.trim();
+
+  if (!html) {
+    notify.error("Nothing to copy.");
+    return;
+  }
+
   try {
-    await navigator.clipboard.writeText(preview.innerHTML);
+    await navigator.clipboard.writeText(html);
 
-    const originalText = copyHtmlBtn.innerText;
-
-    copyHtmlBtn.innerText = 'COPIED!';
-
-    setTimeout(() => {
-      copyHtmlBtn.innerText = originalText;
-    }, 2000);
-
+    notify.success("Copied HTML to clipboard!");
   } catch (err) {
-    alert('Failed to copy HTML.');
+    notify.error("Failed to copy HTML.");
   }
 });
 


### PR DESCRIPTION
## Summary

Improve the Copy HTML functionality by adding user-friendly success and error notifications using the shared notification system.

## Related Issue

Closes #428 

<!-- Example: Closes #123 -->

## Changes

* Added validation to prevent copying when there is no HTML content available.
* Replaced the temporary "COPIED!" button text with consistent success notifications.
* Added an error notification when the clipboard operation fails.
* Added an error notification when users attempt to copy empty content.
* Leveraged the existing shared notification system (`notify.success` and `notify.error`) for a consistent user experience across the project.
* Removed reliance on browser alerts and temporary button text for feedback.

## Testing

* [ ] Added/updated tests
* [x] Tested locally (describe steps below)

## Testing Steps

1. Open the Markdown Editor and enter Markdown content.
2. Click **Copy HTML** and verify that a **"Copied HTML to clipboard!"** success notification is displayed and the rendered HTML is copied to the clipboard.
3. Clear the editor and click **Copy HTML** to verify that a **"Nothing to copy."** error notification is shown.
4. Confirm that no browser alerts appear and existing editor functionality remains unaffected.

## Contributor Details

* **Name:** Lovepreet Kaur
* **GitHub Username:** @love25-codes 
* **Program (SSoC / GSSoC / Hacktoberfest / Other):** SSoC

## Checklist before requesting a review

* [x] Code follows the project's conventions
* [x] No secrets or `.env` values are committed
* [x] I have performed a self-review of my code
* [x] Documentation has been updated if needed
* [x] CI passes
* [x] Linked the related issue above