### PR TITLE
download markdown notification added

### DIFF
--- a/tools/markdown-editor/editor.js
+++ b/tools/markdown-editor/editor.js
@@ -73,9 +73,15 @@ copyHtmlBtn.addEventListener('click', async () => {
     alert('Failed to copy HTML.');
   }
 });
-
 downloadBtn.addEventListener('click', () => {
-  const blob = new Blob([input.value], {
+  const markdown = input.value.trim();
+
+  if (!markdown) {
+    notify.error("Nothing to download.");
+    return;
+  }
+
+  const blob = new Blob([markdown], {
     type: 'text/markdown'
   });
 
@@ -93,6 +99,8 @@ downloadBtn.addEventListener('click', () => {
   document.body.removeChild(a);
 
   URL.revokeObjectURL(url);
+
+  notify.success("Markdown file downloaded!");
 });
 
 init();


### PR DESCRIPTION
## Summary

Improve the Download .MD functionality by adding user-friendly success and error notifications using the shared notification system and preventing empty Markdown downloads.

## Related Issue

Closes #430 

<!-- Example: Closes #123 -->

## Changes

* Added validation to prevent downloading an empty Markdown file.
* Displayed an error notification when users attempt to download without any Markdown content.
* Added a success notification after the Markdown file download is initiated.
* Leveraged the existing shared notification system (`notify.success` and `notify.error`) for consistent feedback across the application.
* Preserved the existing download functionality while improving the overall user experience.

## Testing

* [ ] Added/updated tests
* [x] Tested locally (describe steps below)

## Testing Steps

1. Open the Markdown Editor and enter Markdown content.
2. Click **Download .MD** and verify that the file downloads successfully and a **"Markdown file downloaded!"** success notification is displayed.
3. Clear the editor and click **Download .MD** again to verify that a **"Nothing to download."** error notification is shown and no file is downloaded.
4. Confirm that all other editor features (live preview, clear, and copy HTML) continue to function correctly.

## Contributor Details

* **Name:** Lovepreet Kaur
* **GitHub Username:** @love25-codes 
* **Program (SSoC / GSSoC / Hacktoberfest / Other):** SSoC

## Checklist before requesting a review

* [x] Code follows the project's conventions
* [x] No secrets or `.env` values are committed
* [x] I have performed a self-review of my code
* [x] Documentation has been updated if needed
* [x] CI passes
* [x] Linked the related issue above