### PR TITLE
feat: add Copy Input button for original text

### DIFF
--- a/tools/linkedin-text-formatter/formatter.html
+++ b/tools/linkedin-text-formatter/formatter.html
@@ -221,6 +221,10 @@
       <textarea id="input" placeholder="Type your text here..."></textarea>
 
       <div class="btn-group">
+      <button id="copyInputBtn">Copy Input</button>
+      </div>
+
+      <div class="btn-group">
         <button id="boldBtn">Bold</button>
         <button id="italicBtn">Italic</button>
         <button id="boldItalicBtn">Bold Italic</button>

--- a/tools/linkedin-text-formatter/formatter.js
+++ b/tools/linkedin-text-formatter/formatter.js
@@ -207,7 +207,7 @@ document.getElementById("copyBtn").addEventListener("click", async () => {
   }
 
   await navigator.clipboard.writeText(text);
-    notify.success("Copied to clipboard!");
+    notify.success("Output copied to clipboard!");
 });
 
 
@@ -271,6 +271,18 @@ document.getElementById("strikeBtn").addEventListener("click", () => {
 );
 
 restoreInputFocus(start, end);
+});
+
+document.getElementById("copyInputBtn").addEventListener("click", async () => {
+  const text = input.value.trim();
+
+  if (!text) {
+    notify.error("Nothing to copy.");
+    return;
+  }
+
+  await navigator.clipboard.writeText(text);
+  notify.success("Input copied to clipboard!");
 });
 
 


### PR DESCRIPTION
## Summary

Added a **Copy Input** button to the LinkedIn Text Formatter, allowing users to quickly copy the original input text with appropriate success and error notifications.

## Related Issue

Closes #437 

<!-- Example: Closes #123 -->

## Changes

* Added a new **Copy Input** button.
* Implemented clipboard functionality to copy the contents of the input textarea.
* Reused the existing notification system to display:
  * Success message when the input text is copied.
  * Error message when attempting to copy an empty input field.
* Kept the existing **Copy Output** functionality unchanged.
* Maintained consistent UI styling and button placement.

## Testing

<!-- How did you verify this works? -->

* [ ] Added/updated tests
* [x] Tested locally (describe steps below)

## Testing Steps

1. Enter text into the **Input** textarea.
2. Click **Copy Input** and verify that the original text is copied to the clipboard and a success notification is displayed.
3. Clear the input field, click **Copy Input**, and verify that an error notification ("Nothing to copy.") is shown without copying any text.

## Contributor Details

* Name: Lovepreet Kaur
* GitHub Username: @love25-codes 
* Program (SSoC / GSSoC / Hacktoberfest / Other): SSoC

## Checklist before requesting a review

* [x] Code follows the project's conventions
* [x] No secrets or `.env` values are committed
* [x] I have performed a self-review of my code
* [ ] Documentation has been updated if needed
* [ ] CI passes
* [x] Linked the related issue above