### PR TITLE
feat: linked in character limit warning

### DIFF
--- a/tools/linkedin-text-formatter/formatter.html
+++ b/tools/linkedin-text-formatter/formatter.html
@@ -144,6 +144,7 @@
     resize: vertical;
 }
 
+
 .history-hint {
   margin: 5px 0 2px;
   padding: 10px 12px;
@@ -157,6 +158,27 @@
 
 .history-hint strong {
   color: var(--text);
+}
+
+
+.limit-warning {
+  display: none;
+
+  margin: 1px 0 10px;
+  padding: 10px 22px;
+
+  border: 2px solid #e6a700;
+  border-left: 6px solid #ff9800;
+  border-radius: 8px;
+
+  background: #fff8e1;
+  color: #8a5a00;
+
+  font-size: 0.95rem;
+  font-weight: 700;
+  line-height: 1.5;
+
+  box-shadow: 0 2px 6px rgba(52, 45, 45, 0.08);
 }
 
       @media (max-width: 600px) {
@@ -257,6 +279,10 @@
   <span>Characters: <strong id="charCount">0</strong></span>
   <span>Words: <strong id="wordCount">0</strong></span>
 </div>
+
+<p id="limitWarning" class="limit-warning">
+  ⚠ Too Long for LinkedIn
+</p>
 
       <label>Output</label>
       <textarea id="output" placeholder="Formatted text will appear here..." readonly></textarea>

--- a/tools/linkedin-text-formatter/formatter.js
+++ b/tools/linkedin-text-formatter/formatter.js
@@ -5,6 +5,10 @@ const output = document.getElementById("output");
 const charCount = document.getElementById("charCount");
 const wordCount = document.getElementById("wordCount");
 
+const LINKEDIN_CHARACTER_LIMIT = 3000;
+const limitWarning = document.getElementById("limitWarning");
+limitWarning.style.display = "none";
+
 let history = [];
 
 const styleNames = {
@@ -97,13 +101,19 @@ function validateInput() {
 function updateCounter() {
   const text = input.value;
 
-  charCount.textContent = text.length;
+ charCount.textContent = text.length;
 
-  const words = text.trim()
-    ? text.trim().split(/\s+/).length
-    : 0;
+const words = text.trim()
+  ? text.trim().split(/\s+/).length
+  : 0;
 
-  wordCount.textContent = words;
+wordCount.textContent = words;
+
+if (text.length > LINKEDIN_CHARACTER_LIMIT) {
+  limitWarning.style.display = 'inline-block';
+} else {
+  limitWarning.style.display = 'none';
+}
 }
 
 input.addEventListener("input", updateCounter);


### PR DESCRIPTION
## Summary

Added a configurable LinkedIn character limit warning that alerts users when their input exceeds the recommended length, helping them create LinkedIn-friendly posts before formatting.

## Related Issue

Closes #441 

<!-- Example: Closes #123 -->

## Changes

* Added a configurable `LINKEDIN_CHARACTER_LIMIT` constant (default: 3000 characters).
* Added a warning message that appears when the input exceeds the configured character limit.
* Updated the character counter logic to dynamically show and hide the warning based on the current input length.
* Styled the warning banner to make it visually distinct while remaining consistent with the application's theme.
* Kept the warning informational only without restricting formatting or editing functionality.
* Preserved the existing character counter, word counter, and formatting features.

## Testing

<!-- How did you verify this works? -->

* [ ] Added/updated tests
* [x] Tested locally (describe steps below)

## Testing Steps

1. Open the LinkedIn Text Formatter and verify that the warning is hidden on initial page load.
2. Enter text with fewer than 3000 characters and confirm that only the character and word counters update without displaying the warning.
3. Paste or type text exceeding 3000 characters and verify that the "⚠ Too Long for LinkedIn" warning appears. Delete characters until the count drops below the limit and confirm that the warning disappears automatically.

## Screenshots:
### After:
<img width="1300" height="693" alt="image" src="https://github.com/user-attachments/assets/22432144-8498-4a16-9118-2d9214ed7b96" />


## Contributor Details

* Name: Lovepreet Kaur
* GitHub Username: @love25-codes 
* Program (SSoC / GSSoC / Hacktoberfest / Other): SSoC

## Checklist before requesting a review

* [x] Code follows the project's conventions
* [x] No secrets or `.env` values are committed
* [x] I have performed a self-review of my code
* [ ] Documentation has been updated if needed
* [ ] CI passes
* [x] Linked the related issue above
```