### PR TITLE
Use locally bundled CodeMirror and Pyodide assets in Compiler tool

### DIFF
--- a/tools/compiler/compiler.html
+++ b/tools/compiler/compiler.html
@@ -15,10 +15,10 @@
     <meta name="twitter:description" content="Online code editor and compiler for multiple languages.">
     <meta name="twitter:image" content="https://cdn-icons-png.flaticon.com/512/3522/3522262.png">
 
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.13/codemirror.min.css">
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.13/theme/neo.min.css">
+    <link rel="stylesheet" href="vendor/codemirror/codemirror.min.css">
+    <link rel="stylesheet" href="vendor/codemirror/theme/neo.min.css">
 
-    <script src="https://cdn.jsdelivr.net/pyodide/v0.23.4/full/pyodide.js"></script>
+    <script src="vendor/pyodide/pyodide.js"></script>
 
     <link rel="stylesheet" href="../../assets/css/notifications.css">
     <script src="../../assets/js/notifications.js" defer></script>
@@ -389,13 +389,13 @@
     <footer>
         <a href="../../index.html">&larr; Back to Home</a>
     </footer>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.13/codemirror.min.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.13/addon/edit/closebrackets.min.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.13/mode/javascript/javascript.min.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.13/mode/python/python.min.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.13/mode/xml/xml.min.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.13/mode/css/css.min.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.13/mode/htmlmixed/htmlmixed.min.js"></script>
+    <script src="vendor/codemirror/codemirror.min.js"></script>
+    <script src="vendor/codemirror/addon/edit/closebrackets.min.js"></script>
+    <script src="vendor/codemirror/mode/javascript/javascript.min.js"></script>
+    <script src="vendor/codemirror/mode/python/python.min.js"></script>
+    <script src="vendor/codemirror/mode/xml/xml.min.js"></script>
+    <script src="vendor/codemirror/mode/css/css.min.js"></script>
+    <script src="vendor/codemirror/mode/htmlmixed/htmlmixed.min.js"></script>
     <script src="compiler.js"></script>
 </body>
 


### PR DESCRIPTION
## Summary

This PR replaces external CDN references in the Compiler tool with the corresponding locally bundled assets available under `tools/compiler/vendor`.

## Changes

- Replaced CodeMirror CSS CDN references with local vendor paths.
- Replaced CodeMirror JavaScript CDN references with local vendor paths.
- Replaced the Pyodide CDN reference with the local bundled `pyodide.js`.
- Removed direct runtime dependency on external CDNs from `compiler.html`.

## Why

Using locally bundled assets aligns the Compiler tool with the project's privacy-first and offline-first goals by reducing reliance on third-party CDNs.

## Testing

- Verified all external `cdnjs.cloudflare.com` references were removed.
- Verified all external `cdn.jsdelivr.net` references were removed.
- Confirmed the compiler references local assets from the `vendor` directory.

closes #336