### PR TITLE
fix: replaced native alerts in email-validator

### DIFF
--- a/tools/email-validator/email-validator.js
+++ b/tools/email-validator/email-validator.js
@@ -137,10 +137,10 @@ Role-based Address: ${roleResult}`;
 
    navigator.clipboard.writeText(analysisText)
         .then(() => {
-            alert('Analysis result copied to clipboard successfully.');
+            notify.success('Analysis result copied to clipboard successfully.');
         })
         .catch(() => {
-            alert('Unable to copy analysis result to clipboard.');
+            notify.error('Unable to copy analysis result to clipboard.');
         });
 }
 
@@ -150,7 +150,7 @@ function validateEmail() {
     const typoAction = document.getElementById('typoAction');
     
    if (!email) {
-        alert('No text in the input field.');
+        notify.error('No text in the input field.');
     
     return;
 }


### PR DESCRIPTION
## Summary

Replace native browser alert dialogs in Email Validator with toast notifications using the shared notification utility for a more consistent user experience.

## Related Issue

Closes #471 

<!-- Example: Closes #123 -->

## Changes

* Replaced native `alert()` dialogs shown when attempting to analyze with empty input field with `notify.error()` and `notify.success()` toast notifications wherever suitable.
* Improved consistency with the rest of the Project Toolsuite by using the common notification system instead of browser alert popups.

## Testing

* [ ] Added/updated tests
* [x] Tested locally (describe steps below)


## Contributor Details
Name: Lovepreet Kaur
Github: @love25-codes 
Program: SSoC

* Integrated the shared notification module into Email Validator and replaced native alert dialogs with toast notifications for a more modern and consistent UI.