### PR TITLE
style: align world time tool with design system

### DIFF
--- a/tools/world-time/world-time.css
+++ b/tools/world-time/world-time.css
@@ -28,7 +28,7 @@ body {
 
 /* PLACEHOLDER FIX */
 input::placeholder {
-  color: gray;
+  color: var(--text);
 }
 
 /* CLOCK CARD TEXT FIX */
@@ -112,7 +112,7 @@ header {
 
   transform: translateY(-2px);
 
-  box-shadow: 0 0 15px rgba(96, 165, 250, 0.4);
+ box-shadow: 3px 3px 0 var(--border);
 }
 
 /* TITLE */
@@ -171,7 +171,7 @@ header {
 
   transform: translateY(-2px);
 
-  box-shadow: 0 0 20px rgba(96, 165, 250, 0.4);
+  box-shadow: 3px 3px 0 var(--border);
 }
 
 .action-btn:active {
@@ -249,9 +249,9 @@ main {
 
   background: var(--surface-2);
 
-  box-shadow: var(--shadow);
+  box-shadow: 3px 3px 0 var(--border);
 
-  border-radius: 18px;
+  border-radius: 0;
 }
 
 .hero h2 {
@@ -408,7 +408,7 @@ main {
 
   padding: 25px;
 
-  border-radius: 14px;
+  border-radius: 0;
 
   transition: 0.25s;
 }
@@ -418,7 +418,7 @@ main {
 
   border-color: var(--card-hover);
 
-  box-shadow: 0 0 25px rgba(96, 165, 250, 0.4);
+  box-shadow: 3px 3px 0 var(--border);
 }
 
 .clock-card h4 {
@@ -465,7 +465,7 @@ select {
 
   border: 2px solid var(--border);
 
-  border-radius: 8px;
+  border-radius: 4px;
 
   font-family: "Courier New", monospace;
 
@@ -484,7 +484,7 @@ input:focus {
 
   border-color: var(--card-hover);
 
-  box-shadow: 0 0 12px rgba(96, 165, 250, 0.25);
+  box-shadow: 3px 3px 0 var(--border);
 }
 
 /* dropdown options */
@@ -518,7 +518,7 @@ select:focus {
 
   color: var(--card-hover);
 
-  border-radius: 10px;
+  border-radius: 0;
 }
 
 /* ================= DEV BUTTONS ================= */
@@ -602,7 +602,7 @@ select {
 
   padding: 12px;
 
-  border-radius: 8px;
+  border-radius: 4px;
 
   font-family: inherit;
 }
@@ -627,7 +627,7 @@ select option {
 
   cursor: pointer;
 
-  border-radius: 8px;
+  border-radius: 0;
 }
 
 .convert-btn:hover {
@@ -653,7 +653,7 @@ input[type="date"] {
 
   padding: 12px;
 
-  border-radius: 8px;
+  border-radius: 4px;
 
   font-family: inherit;
 }
@@ -667,14 +667,14 @@ input[type="date"]::-webkit-calendar-picker-indicator {
 }
 
 input[type="date"]:hover {
-  box-shadow: 0 0 10px var(--card-hover);
+  box-shadow: 3px 3px 0 var(--border);
 }
 
 footer {
             margin-top: 60px;
             padding: 30px 20px;
             text-align: center;
-            border-radius: 12px 12px 0 0;
+            border-radius: 0;
         }
 
         footer a {


### PR DESCRIPTION
## Summary

Updated the World Time tool's styling to comply with the project's neobrutalist design system by removing excessive border radii, standardizing shadows, and ensuring theme-based styling.

## Related Issue

Closes #445

<!-- Example: Closes #123 -->

## Changes

* Removed large `border-radius` values from cards, panels, buttons, and other UI components to match the project's sharp-edge design language.
* Updated input and date input elements to use the allowed border radius (0–4px maximum).
* Replaced soft glow box-shadows on cards and buttons with the standard neobrutalist offset shadow (`box-shadow: 3px 3px 0 var(--border);`).
* Ensured UI components use CSS variables from `theme.css` instead of hardcoded color values wherever applicable.
* Preserved the existing layout, responsiveness, and functionality while bringing the styling in line with the project's `DESIGN.md` guidelines.

## Testing

<!-- How did you verify this works? -->

* [ ] Added/updated tests
* [x] Tested locally (describe steps below)

## Testing Steps

1. Open the World Time tool and verify that cards, buttons, and panels have sharp corners with no excessive border radius.
2. Confirm that buttons and interactive elements use the standard offset box-shadow instead of soft glow effects.
3. Toggle between light and dark themes and verify that all colors are sourced from theme variables and render correctly.
4. Check the layout on both desktop and mobile viewports to ensure styling changes did not affect responsiveness.

## Contributor Details

* Name: Lovepreet Kaur
* GitHub Username: @love25-codes 
* Program (SSoC / GSSoC / Hacktoberfest / Other): SSoC

## Checklist before requesting a review

* [x] Code follows the project's conventions
* [x] No secrets or `.env` values are committed
* [x] I have performed a self-review of my code
* [ ] Documentation has been updated if needed
* [ ] CI passes
* [x] Linked the related issue above