### PR TITLE
style: fixed the styling issues in password-lab

### DIFF
--- a/tools/password lab/password-logic.js
+++ b/tools/password lab/password-logic.js
@@ -46,18 +46,52 @@ function analyze() {
 
 function updateDisplay(val, entropy, pool, issues) {
     // UI Colors based on Entropy
-    let color = "#ff4d4d";
-    let status = "CRITICAL";
-    
-    if (entropy > 40) { color = "#ffa64d"; status = "WEAK"; }
-    if (entropy > 60) { color = "#ffff4d"; status = "FAIR"; }
-    if (entropy > 80) { color = "#4dff4d"; status = "STRONG"; }
-    if (entropy > 110) { color = "#00ffff"; status = "ELITE"; }
+    // UI state based on Entropy
+let color = "var(--status-critical)";
+let status = "CRITICAL";
+let statusClass = "status-critical";
+
+if (entropy > 40) {
+    color = "var(--status-weak)";
+    status = "WEAK";
+    statusClass = "status-weak";
+}
+
+if (entropy > 60) {
+    color = "var(--status-fair)";
+    status = "FAIR";
+    statusClass = "status-fair";
+}
+
+if (entropy > 80) {
+    color = "var(--status-strong)";
+    status = "STRONG";
+    statusClass = "status-strong";
+}
+
+if (entropy > 110) {
+    color = "var(--status-elite)";
+    status = "ELITE";
+    statusClass = "status-elite";
+}
 
     meterBar.style.width = Math.min(entropy, 100) + "%";
-    meterBar.style.backgroundColor = color;
-    statusText.innerText = `STATUS: ${status}`;
-    statusText.style.color = color === "#ffff4d" ? "#000" : color;
+meterBar.style.backgroundColor = color;
+
+statusText.innerText = `STATUS: ${status}`;
+
+// Remove any previous status class
+statusText.classList.remove(
+    "status-critical",
+    "status-weak",
+    "status-fair",
+    "status-strong",
+    "status-elite"
+);
+
+// Apply the new one
+statusText.classList.add(statusClass);
+statusText.style.color = color;
 
     entropyVal.innerText = Math.floor(entropy) + " bits";
     poolVal.innerText = pool;
@@ -65,7 +99,14 @@ function updateDisplay(val, entropy, pool, issues) {
     // Crack Time: Assumes 100 Trillion guesses/sec (Modern GPU Cluster)
     const seconds = Math.pow(2, entropy) / 1e14;
     timeVal.innerText = formatTime(seconds);
-    timeVal.style.color = entropy < 60 ? "#d00" : "#000";
+    
+    timeVal.classList.remove("time-danger", "time-safe");
+
+if (entropy < 60) {
+    timeVal.classList.add("time-danger");
+} else {
+    timeVal.classList.add("time-safe");
+}
 
     vulnsDiv.innerHTML = issues.length ? 
         issues.map(i => `<div class="issue">${i}</div>`).join('') : 
@@ -84,9 +125,26 @@ function formatTime(s) {
 
 function reset() {
     meterBar.style.width = "0%";
+    meterBar.style.backgroundColor = "";
+
     statusText.innerText = "STATUS: WAITING";
+
+    statusText.classList.remove(
+        "status-critical",
+        "status-weak",
+        "status-fair",
+        "status-strong",
+        "status-elite"
+    );
+
+    statusText.style.color = "";
+
     entropyVal.innerText = "0 bits";
     poolVal.innerText = "0";
+
     timeVal.innerText = "Instant";
+    timeVal.classList.remove("time-danger", "time-safe");
+    timeVal.style.color = "";
+
     vulnsDiv.innerHTML = "No patterns detected.";
 }

--- a/tools/password lab/password-tester.html
+++ b/tools/password lab/password-tester.html
@@ -36,6 +36,15 @@
         --color-text: var(--text);
         --color-bg: var(--bg);
         --color-border: var(--border);
+
+        --status-critical: #ff4d4d;
+--status-weak: #ffa64d;
+--status-fair: #ffff4d;
+--status-strong: #4dff4d;
+--status-elite: #00ffff;
+
+--time-danger: #d00;
+--time-safe: var(--text);
       }
 
       /*Global Layout */
@@ -206,6 +215,34 @@
         background-color: var(--text);
         color: var(--bg);
       }
+
+      .status-critical {
+  color: var(--status-critical);
+}
+
+.status-weak {
+  color: var(--status-weak);
+}
+
+.status-fair {
+  color: var(--status-fair);
+}
+
+.status-strong {
+  color: var(--status-strong);
+}
+
+.status-elite {
+  color: var(--status-elite);
+}
+
+.time-danger {
+  color: var(--time-danger);
+}
+
+.time-safe {
+  color: var(--time-safe);
+}
 
       /*Responsive*/
       @media (max-width: 700px) {


### PR DESCRIPTION
## Summary

Fix dark mode visibility issues and properly reset UI styling in the Password Lab tool by replacing hardcoded JavaScript colors with CSS variables and restoring default styles when the password input is cleared.

## Related Issue

Closes #447

<!-- Example: Closes #123 -->

## Changes

* Replaced hardcoded text colors (`#000` and `#d00`) in `password-logic.js` with CSS variable-based styling.
* Added CSS variables for password strength states and crack time text colors.
* Updated the password status text to use CSS variable colors, ensuring correct visibility in both light and dark themes.
* Fixed the crack time estimation text to adapt to the active theme instead of always using black.
* Updated the `reset()` function to clear the status text color and reset the strength meter background color to their default states.
* Preserved existing password strength evaluation logic while improving theme compatibility and UI consistency.

## Testing

<!-- How did you verify this works? -->

* [ ] Added/updated tests
* [x] Tested locally (describe steps below)

## Testing Steps

1. Open `password-tester.html` and enable Dark Mode.
2. Enter passwords of varying strengths (e.g., weak, fair, strong, elite) and verify that the status text, strength meter, and crack time estimation display the appropriate colors in both light and dark themes.
3. Clear the password input completely and verify that the status resets to `STATUS: WAITING`, the status text returns to its default color, and the strength meter resets to its default appearance.

## Contributor Details

* Name: Lovepreet Kaur
* GitHub Username: @love25-codes 
* Program (SSoC / GSSoC / Hacktoberfest / Other): SSoC

## Checklist before requesting a review

* [x] Code follows the project's conventions
* [x] No secrets or `.env` values are committed
* [x] I have performed a self-review of my code
* [ ] Documentation has been updated if needed
* [ ] CI passes
* [x] Linked the related issue above