### PR TITLE
fixed the responsive workspace layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -136,12 +136,15 @@
       transform: translate(-2px, -2px);
       box-shadow: 4px 4px 0px var(--border);
     }
+.workspace {
+    display: grid;
+    gap: 40px;
 
-    .workspace {
-      display: grid;
-      grid-template-columns: 220px 1fr 280px;
-      gap: 40px;
-    }
+    grid-template-columns: 220px 1fr 280px;
+
+    grid-template-areas:
+        "tags tools recent";
+}
 
     aside h3 {
       font-size: 0.8rem;
@@ -493,10 +496,17 @@
       box-shadow: 6px 6px 0 var(--border);
     }
 
-    @media (max-width: 850px) {
-      .workspace {
-        grid-template-columns: 1fr;
-      }
+    @media (max-width: 800px) {
+      .workspace{
+
+    grid-template-columns:1fr;
+
+    grid-template-areas:
+
+        "tools"
+        "tags"
+        "recent";
+}
 
       .tag-list {
         display: flex;
@@ -598,10 +608,9 @@
         width: 90%;
       }
 
-      .workspace {
-        grid-template-columns: 1fr;
-        gap: 20px;
-      }
+      .workspace{
+        gap:20px;
+     }
 
       .tag-list {
         display: flex;
@@ -833,6 +842,32 @@
       transform: translateY(-1px) scale(0.98);
       box-shadow: 3px 3px 0 var(--border);
     }
+
+    .workspace > aside:first-child {
+    grid-area: tags;
+}
+
+.workspace > main {
+    grid-area: tools;
+}
+
+.workspace > aside:last-child {
+    grid-area: recent;
+}
+
+@media (max-width:1024px){
+
+    .workspace{
+
+        grid-template-columns:220px 1fr;
+
+        grid-template-areas:
+
+            "tags tools"
+            "recent recent";
+    }
+
+}
   </style>
   <script defer src="https://cloud.umami.is/script.js" data-website-id="e2150d65-a009-409f-b3bd-b11afccb3a13"></script>
   <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-6760380500809289"


### PR DESCRIPTION
## Summary

Improves the homepage responsive workspace layout by introducing progressive grid collapsing and reordering sections on smaller screens for a better user experience.

## Related Issue

Closes #448

<!-- Example: Closes #123 -->

## Changes

* Added `grid-template-areas` to the workspace layout for better control over responsive section ordering.
* Assigned grid areas to the Filter Tags sidebar, Tools section, and Recent Tools sidebar.
* Introduced a new breakpoint at `1024px` to move the Recent Tools sidebar below the main content, preventing the tools grid from becoming overly compressed.
* Updated the mobile breakpoint to `800px` to collapse the layout into a single column, matching the issue requirements.
* Reordered the mobile layout so that the Search Input and Tools Grid appear first, followed by the Filter Tags section and finally the Recent Tools sidebar.
* Retained horizontal scrolling for filter tags on smaller screens to prevent the tag list from pushing the main content below the fold.
* Simplified the `768px` media query by only adjusting spacing (`gap`) instead of redefining the entire workspace layout.

## Testing

* [ ] Added/updated tests
* [x] Tested locally (describe steps below)

## Testing Steps

1. Opened `index.html` in the browser and verified the desktop layout (>1024px) remains unchanged.
2. Resized the viewport to approximately `900px` and confirmed the Recent Tools sidebar moves below the main content while the tools grid has sufficient width.
3. Resized the viewport to `800px` and below to verify the layout collapses into a single column with the order: Search & Tools → Filter Tags → Recent Tools.
4. Verified that filter tags become horizontally scrollable on mobile and no longer push the search bar below the fold.
5. Confirmed the layout behaves correctly across common viewport widths (1200px, 1024px, 900px, 800px, 768px, 600px, and 500px).

## Contributor Details

* Name: Lovepreet Kaur
* GitHub Username: @love25-codes 
* Program (SSoC / GSSoC / Hacktoberfest / Other): SSoC

## Checklist before requesting a review

* [x] Code follows the project's conventions
* [x] No secrets or `.env` values are committed
* [x] I have performed a self-review of my code
* [ ] Documentation has been updated if needed
* [ ] CI passes
* [x] Linked the related issue above