### PR TITLE
prefetch tools offline

### DIFF
--- a/index.html
+++ b/index.html
@@ -1523,6 +1523,14 @@
       window.addEventListener('load', async () => {
         try {
           const registration = await navigator.serviceWorker.register('./sw.js');
+          await navigator.serviceWorker.ready;
+
+if (navigator.serviceWorker.controller) {
+  navigator.serviceWorker.controller.postMessage({
+    type: "PREFETCH_TOOLS",
+    urls: tools.map(tool => tool.path)
+  });
+}
 
           registration.addEventListener('updatefound', () => {
             const newWorker = registration.installing;

--- a/sw.js
+++ b/sw.js
@@ -1,4 +1,4 @@
-const CACHE_VERSION = 'v4';
+const CACHE_VERSION = 'v5';
 
 const CACHE_NAME = `toolsuite-${CACHE_VERSION}-core`;
 const DYNAMIC_CACHE = `toolsuite-${CACHE_VERSION}-dynamic`;
@@ -21,6 +21,29 @@ const ASSETS_TO_CACHE = [
     './sitemap.xml'
 ];
 
+async function prefetchTools(urls) {
+    const cache = await caches.open(DYNAMIC_CACHE);
+    console.log("[SW] Prefetching", urls.length, "tools");
+
+    for (const url of urls) {
+        console.log("[SW] Cached:", url);
+        try {
+            const cached = await cache.match(url);
+
+            if (!cached) {
+                const response = await fetch(url);
+
+                if (response.ok) {
+                    await cache.put(url, response.clone());
+                    console.log("[SW] Cached:", url);
+                }
+            }
+        } catch (err) {
+            console.warn("[SW] Failed to prefetch:", url);
+        }
+    }
+}
+
 self.addEventListener('install', (event) => {
     event.waitUntil(
         caches.open(CACHE_NAME).then((cache) => {
@@ -29,7 +52,7 @@ self.addEventListener('install', (event) => {
         })
     );
     // Force the waiting service worker to become the active service worker.
-    self.skipWaiting(); 
+    self.skipWaiting();
 });
 
 self.addEventListener('activate', (event) => {
@@ -46,6 +69,14 @@ self.addEventListener('activate', (event) => {
     );
     // Ensure that updates to the service worker take effect immediately
     return self.clients.claim();
+});
+
+self.addEventListener("message", (event) => {
+    if (event.data?.type !== "PREFETCH_TOOLS") {
+        return;
+    }
+
+    event.waitUntil(prefetchTools(event.data.urls));
 });
 
 self.addEventListener('fetch', (event) => {
@@ -94,3 +125,4 @@ self.addEventListener('fetch', (event) => {
         })
     );
 });
+


### PR DESCRIPTION
## Summary

Implement background prefetching of tool pages using the Service Worker to improve offline availability and reduce load times for frequently accessed tools.

## Related Issue

Closes #449 

<!-- Example: Closes #123 -->

## Changes

* Added a `PREFETCH_TOOLS` message handler in the Service Worker to receive tool URLs from the client.
* Implemented a `prefetchTools()` function that caches tool pages in the dynamic cache.
* Prevented duplicate network requests by checking whether a tool is already cached before fetching it.
* Updated the homepage to send the complete list of tool URLs to the Service Worker after it becomes active.
* Reused the existing dynamic cache for prefetched resources to maintain the current caching strategy.
* Preserved existing offline navigation and cache versioning behavior without affecting other Service Worker functionality.

## Testing

<!-- How did you verify this works? -->

* [ ] Added/updated tests
* [x] Tested locally (describe steps below)

## Testing Steps

1. Start the application locally and register the Service Worker.
2. Open DevTools → Console and verify that the Service Worker logs show tool pages being prefetched and cached.
3. Open DevTools → Application → Cache Storage and confirm that the `toolsuite-v5-dynamic` cache contains the prefetched tool pages.

## Contributor Details

* Name: Lovepreet Kaur
* GitHub Username: @love25-codes 
* Program (SSoC / GSSoC / Hacktoberfest / Other): SSoC

## Checklist before requesting a review

* [x] Code follows the project's conventions
* [x] No secrets or `.env` values are committed
* [x] I have performed a self-review of my code
* [ ] Documentation has been updated if needed
* [ ] CI passes
* [x] Linked the related issue above