### PR TITLE
docs: clarify external CDN library policy

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -10,9 +10,47 @@ Practical reference for contributors building or modifying tools. Follow this to
 
 **Monospace-first.** All body text uses JetBrains Mono. Headings use Space Grotesk. No other font families.
 
-**Privacy-first.** No external JS libraries. No tracking scripts. Google Fonts is the only external CDN dependency.
+**Privacy-first.** No tracking scripts or third-party analytics. The project avoids external JavaScript libraries wherever practical, but certain client-side tools require well-established libraries delivered from trusted CDNs. These libraries run entirely in the browser and do not transmit user data to external services. Google Fonts remains the only font CDN dependency.
 
 **Dual-theme.** Every color value must come from a CSS variable so dark mode works automatically.
+
+---
+
+### External JavaScript Library Policy
+
+Most tools should be implemented using native browser APIs whenever possible.
+
+Some utilities require specialized client-side libraries that would be impractical to replace with vanilla JavaScript. These libraries are approved exceptions to the general guideline because they execute entirely within the user's browser.
+
+Current approved external libraries include:
+
+- pdf-lib (PDF creation and editing)
+- pdf.js (PDF rendering)
+- JSZip (ZIP archive creation and extraction)
+- FileSaver.js (download support)
+- Tesseract.js (OCR)
+- PapaParse (CSV parsing)
+- Pyodide (Python runtime for the Online Compiler)
+
+These libraries must:
+
+- Execute completely client-side.
+- Never upload user files or data to third-party services.
+- Be loaded only from trusted HTTPS CDNs.
+- Be included only by tools that require their functionality.
+
+---
+
+### Adding New External Libraries
+
+Before introducing a new CDN dependency, contributors should ensure that:
+
+- Native browser APIs cannot reasonably provide the required functionality.
+- The library operates entirely client-side.
+- It is distributed from a reputable HTTPS CDN.
+- It respects user privacy and does not collect or transmit user data.
+- It has an active maintenance history and a suitable open-source license.
+- The dependency is documented in this design guide.
 
 ---
 


### PR DESCRIPTION
## Summary

Updated `DESIGN.md` to clarify the project's external JavaScript library policy by documenting approved CDN exceptions and defining guidelines for adding future client-side dependencies.

## Related Issue

Closes #450 

<!-- Example: Closes #123 -->

## Changes

* Updated the **Privacy-first** philosophy to accurately reflect the project's use of approved client-side external libraries.
* Added an **External JavaScript Library Policy** section explaining why certain libraries are permitted.
* Documented the current approved external CDN libraries, including:
  * pdf-lib
  * pdf.js
  * JSZip
  * FileSaver.js
  * Tesseract.js
  * PapaParse
  * Pyodide
* Added criteria for introducing new external CDN libraries, including:
  * Client-side execution only
  * Trusted HTTPS CDN sources
  * Privacy-respecting behavior
  * Justified use when native browser APIs are insufficient
  * Documentation requirements for future dependencies
* Kept the changes documentation-only with no impact on application functionality.

## Testing

* [ ] Added/updated tests
* [x] Tested locally (describe steps below)

## Testing Steps

1. Opened `DESIGN.md` in a Markdown preview.
2. Verified that the new sections render correctly and follow the existing document structure.
3. Reviewed the document to ensure the updated policy aligns with the current codebase and resolves the documented discrepancy.

## Contributor Details

* Name: Lovepreet Kaur
* GitHub Username: @love25-codes 
* Program (SSoC / GSSoC / Hacktoberfest / Other): SSoC

## Checklist before requesting a review

* [x] Code follows the project's conventions
* [x] No secrets or `.env` values are committed
* [x] I have performed a self-review of my code
* [x] Documentation has been updated if needed
* [ ] CI passes
* [x] Linked the related issue above