### PR TITLE
added markdown slides generator feature successfully

### DIFF
--- a/index.html
+++ b/index.html
@@ -1248,6 +1248,11 @@
         tags: ["Dev", "Utilities"],
       },
       {
+        name: "Markdown Slides Generator",
+        path: "tools/markdown-slides/index.html",
+        tags: ["Dev", "Utilities"],
+      },
+      {
         name: "Kubernetes Manifest Generator",
         path: "tools/kubernetes-manifest-generator/kubernetes-manifest-generator.html",
         tags: ["Dev", "DevOps"],

--- a/tools/markdown-slides/index.html
+++ b/tools/markdown-slides/index.html
@@ -1,0 +1,75 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Markdown Slides Generator</title>
+
+    <link rel="stylesheet" href="style.css">
+
+    <!-- Markdown parser -->
+    <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
+</head>
+
+<body>
+
+    <header>
+
+    <div class="top-bar">
+
+        <h1>📽 Markdown Slides Generator</h1>
+
+        <div class="top-buttons">
+
+            <button id="homeBtn">🏠 Back to Home</button>
+
+            <button id="themeBtn">🌙 Dark Mode</button>
+
+        </div>
+
+    </div>
+
+</header>
+
+    <main class="container">
+
+        <!-- LEFT PANEL -->
+
+        <section class="editor-panel">
+
+            <h2>Markdown</h2>
+
+            <textarea id="markdownInput"></textarea>
+
+        </section>
+
+        <!-- RIGHT PANEL -->
+
+        <section class="preview-panel">
+
+            <div id="slideContainer"></div>
+
+            <div class="controls">
+
+                <button id="prevBtn">◀ Previous</button>
+
+                <span id="slideCounter"></span>
+
+                <button id="nextBtn">Next ▶</button>
+
+            </div>
+
+            <button id="downloadBtn">
+                Download HTML
+            </button>
+
+        </section>
+
+    </main>
+
+    <script src="script.js"></script>
+
+</body>
+
+</html>

--- a/tools/markdown-slides/script.js
+++ b/tools/markdown-slides/script.js
@@ -1,0 +1,277 @@
+const markdownInput = document.getElementById("markdownInput");
+const slideContainer = document.getElementById("slideContainer");
+
+const prevBtn = document.getElementById("prevBtn");
+const nextBtn = document.getElementById("nextBtn");
+const slideCounter = document.getElementById("slideCounter");
+const downloadBtn = document.getElementById("downloadBtn");
+
+const homeBtn = document.getElementById("homeBtn");
+const themeBtn = document.getElementById("themeBtn");
+
+let slides = [];
+let currentSlide = 0;
+
+// Default markdown shown on page load
+markdownInput.value = `# Markdown Slides
+
+Write presentations using Markdown.
+
+---
+
+# Features
+
+- Live Preview
+- Slide Navigation
+- HTML Export
+
+---
+
+# Thank You
+
+Questions?
+`;
+
+function parseSlides() {
+    const markdown = markdownInput.value.trim();
+
+    if (!markdown) {
+        slides = ["# No Content\n\nStart typing to create slides."];
+        currentSlide = 0;
+        renderSlide();
+        return;
+    }
+
+    slides = markdown
+        .split(/^---$/gm)
+        .map(slide => slide.trim())
+        .filter(slide => slide.length > 0);
+
+    if (currentSlide >= slides.length) {
+        currentSlide = slides.length - 1;
+    }
+
+    renderSlide();
+}
+
+function renderSlide() {
+
+    if (slides.length === 0) {
+        slideContainer.innerHTML = "";
+        slideCounter.textContent = "0 / 0";
+        return;
+    }
+
+    slideContainer.innerHTML = marked.parse(slides[currentSlide]);
+
+    slideCounter.textContent =
+        `${currentSlide + 1} / ${slides.length}`;
+
+}
+
+function nextSlide() {
+
+    if (currentSlide < slides.length - 1) {
+        currentSlide++;
+        renderSlide();
+    }
+
+}
+
+function previousSlide() {
+
+    if (currentSlide > 0) {
+        currentSlide--;
+        renderSlide();
+    }
+
+}
+
+markdownInput.addEventListener("input", parseSlides);
+
+nextBtn.addEventListener("click", nextSlide);
+
+prevBtn.addEventListener("click", previousSlide);
+
+parseSlides();
+
+homeBtn.addEventListener("click", () => {
+
+    window.location.href = "../../index.html";
+
+});
+
+themeBtn.addEventListener("click", () => {
+
+    document.body.classList.toggle("dark");
+
+    if (document.body.classList.contains("dark")) {
+
+        themeBtn.textContent = "☀️ Light Mode";
+
+    } else {
+
+        themeBtn.textContent = "🌙 Dark Mode";
+
+    }
+
+});
+
+downloadBtn.addEventListener("click", exportPresentation);
+
+function exportPresentation() {
+
+    const htmlSlides = slides.map(slide => {
+
+        return `
+<section class="slide">
+${marked.parse(slide)}
+</section>
+`;
+
+    }).join("");
+
+    const html = `
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+
+<meta charset="UTF-8">
+
+<title>Presentation</title>
+
+<style>
+
+body{
+
+margin:0;
+
+background:#ffe86b;
+
+font-family:Arial,Helvetica,sans-serif;
+
+display:flex;
+
+justify-content:center;
+
+align-items:center;
+
+height:100vh;
+
+}
+
+.slide{
+
+display:none;
+
+width:80%;
+
+background:white;
+
+padding:60px;
+
+border:5px solid black;
+
+box-shadow:10px 10px black;
+
+}
+
+.slide.active{
+
+display:block;
+
+}
+
+h1{
+
+font-size:56px;
+
+}
+
+h2{
+
+font-size:42px;
+
+}
+
+p,li{
+
+font-size:26px;
+
+}
+
+</style>
+
+</head>
+
+<body>
+
+${htmlSlides}
+
+<script>
+
+let current=0;
+
+const slides=document.querySelectorAll('.slide');
+
+function show(i){
+
+slides.forEach(s=>s.classList.remove('active'));
+
+slides[i].classList.add('active');
+
+}
+
+show(0);
+
+document.addEventListener('keydown',e=>{
+
+if(e.key==='ArrowRight'||e.key===' '){
+
+if(current<slides.length-1){
+
+current++;
+
+show(current);
+
+}
+
+}
+
+if(e.key==='ArrowLeft'){
+
+if(current>0){
+
+current--;
+
+show(current);
+
+}
+
+}
+
+});
+
+</script>
+
+</body>
+
+</html>
+`;
+
+    const blob = new Blob([html], { type: "text/html" });
+
+    const url = URL.createObjectURL(blob);
+
+    const link = document.createElement("a");
+
+    link.href = url;
+
+    link.download = "presentation.html";
+
+    link.click();
+
+    URL.revokeObjectURL(url);
+
+}

--- a/tools/markdown-slides/style.css
+++ b/tools/markdown-slides/style.css
@@ -1,0 +1,197 @@
+* {
+    margin: 0;
+    padding: 0;
+    box-sizing: border-box;
+}
+
+body {
+
+    font-family: Arial, Helvetica, sans-serif;
+    background: #ffe86b;
+    padding: 30px;
+}
+
+header {
+
+    margin-bottom: 25px;
+}
+
+h1 {
+
+    font-size: 2rem;
+}
+
+.container {
+
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 25px;
+}
+
+.editor-panel,
+.preview-panel {
+
+    background: white;
+
+    border: 4px solid black;
+
+    box-shadow: 8px 8px black;
+
+    padding: 20px;
+
+    min-height: 80vh;
+}
+
+textarea {
+
+    width: 100%;
+
+    height: 70vh;
+
+    margin-top: 15px;
+
+    padding: 15px;
+
+    resize: none;
+
+    font-size: 16px;
+}
+
+#slideContainer {
+
+    border: 4px solid black;
+
+    min-height: 500px;
+
+    padding: 40px;
+
+    background: #ffffff;
+
+    margin-bottom: 20px;
+}
+
+#slideContainer h1 {
+
+    font-size: 3rem;
+
+    margin-bottom: 20px;
+}
+
+#slideContainer h2 {
+
+    font-size: 2.4rem;
+
+    margin-bottom: 15px;
+}
+
+#slideContainer p {
+
+    font-size: 1.4rem;
+
+    margin: 15px 0;
+}
+
+#slideContainer ul {
+
+    margin-left: 35px;
+
+    font-size: 1.3rem;
+}
+
+.controls {
+
+    display: flex;
+
+    justify-content: space-between;
+
+    align-items: center;
+
+    margin-bottom: 20px;
+}
+
+button {
+
+    cursor: pointer;
+
+    padding: 12px 20px;
+
+    font-size: 16px;
+
+    border: 3px solid black;
+
+    background: #7df9ff;
+
+    box-shadow: 4px 4px black;
+}
+
+button:hover {
+
+    transform: translate(-2px,-2px);
+
+    box-shadow: 6px 6px black;
+}
+
+/* ---------- Top Bar ---------- */
+
+.top-bar {
+
+    display: flex;
+
+    justify-content: space-between;
+
+    align-items: center;
+
+    margin-bottom: 20px;
+
+}
+
+.top-buttons {
+
+    display: flex;
+
+    gap: 12px;
+
+}
+
+/* ---------- Dark Theme ---------- */
+
+body.dark {
+
+    background: #1d1d1d;
+
+    color: white;
+
+}
+
+body.dark .editor-panel,
+body.dark .preview-panel {
+
+    background: #2b2b2b;
+
+    color: white;
+
+}
+
+body.dark textarea {
+
+    background: #1f1f1f;
+
+    color: white;
+
+}
+
+body.dark #slideContainer {
+
+    background: #111;
+
+    color: white;
+
+}
+
+body.dark button {
+
+    background: #ffca28;
+
+    color: black;
+
+}


### PR DESCRIPTION
## Summary

Added a top navigation bar with **Back to Home** and **Dark Mode** buttons to improve navigation and accessibility within the Markdown Slides Generator tool.

## Related Issue

Closes #455 

<!-- Example: Closes #123 -->

## Changes

* Added a **Back to Home** button in the header for quick navigation to the project's homepage.
* Added a **Dark Mode** toggle button to switch between light and dark themes.
* Organized the header into a responsive top bar with grouped action buttons.
* Improved the overall user experience by making navigation and theme switching easily accessible.

## Testing

* [ ] Added/updated tests
* [x] Tested locally (describe steps below)

## Testing Steps

1. Open the Markdown Slides Generator tool in the browser.
2. Verify that the **Back to Home** and **Dark Mode** buttons appear in the header.
3. Click the **Dark Mode** button and confirm that the theme toggles correctly between light and dark modes.
4. Click the **Back to Home** button and verify that it redirects to the project's homepage.

## Screenshots:
<img width="1896" height="1020" alt="image" src="https://github.com/user-attachments/assets/596bb84c-5f82-493c-afa6-7045175ba7f4" />


## Contributor Details

* Name: Lovepreet Kaur
* GitHub Username: @love25-codes 
* Program (SSoC / GSSoC / Hacktoberfest / Other): SSoC

## Checklist before requesting a review

* [x] Code follows the project's conventions
* [x] No secrets or `.env` values are committed
* [x] I have performed a self-review of my code
* [ ] Documentation has been updated if needed
* [ ] CI passes
* [x] Linked the related issue above